### PR TITLE
StayWatch API呼び出しにAPIキー認証を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ staywatch:
   users: "/api/users"
   probability: "/api/probability"
   time: "/api/time"
+  api_key: "your_api_key_here"
 ```
 
 ### 5. MySQL設定ファイルの作成

--- a/src/conf/environments/staywatch_template.yml
+++ b/src/conf/environments/staywatch_template.yml
@@ -3,3 +3,4 @@ staywatch:
   users: "path"
   probability: "path"
   time: "path"
+  api_key: "your_api_key_here"

--- a/src/service/init.go
+++ b/src/service/init.go
@@ -9,6 +9,7 @@ type StayWatch struct {
 	Users       string
 	Probability string
 	Time        string
+	ApiKey      string
 }
 
 type StaywatchUsers struct {
@@ -49,4 +50,5 @@ func init() {
 	staywatch.Users = s.GetString("staywatch.users")
 	staywatch.Probability = s.GetString("staywatch.probability")
 	staywatch.Time = s.GetString("staywatch.time")
+	staywatch.ApiKey = s.GetString("staywatch.api_key")
 }

--- a/src/service/staywatch.go
+++ b/src/service/staywatch.go
@@ -19,6 +19,7 @@ func GetStayWatchMember() ([]StaywatchUsers, error) {
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("X-API-Key", staywatch.ApiKey)
 	client := new(http.Client)
 	resp, err := client.Do(req)
 	if err != nil {
@@ -50,7 +51,13 @@ func GetStayWatchProbability(users []model.User) []Probability {
 	q.Add("time", timeStr)
 	u.RawQuery = q.Encode()
 
-	res, err := http.Get(u.String())
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return []Probability{}
+	}
+	req.Header.Set("X-API-Key", staywatch.ApiKey)
+	client := new(http.Client)
+	res, err := client.Do(req)
 	if err != nil {
 		return []Probability{}
 	}
@@ -97,7 +104,13 @@ func fetchPredictionTime(users []model.User, action string) []Result {
 	q.Add("weekday", strconv.Itoa(w))
 	u.RawQuery = q.Encode()
 
-	res, err := http.Get(u.String())
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return []Result{}
+	}
+	req.Header.Set("X-API-Key", staywatch.ApiKey)
+	client := new(http.Client)
+	res, err := client.Do(req)
 	if err != nil {
 		return []Result{}
 	}


### PR DESCRIPTION
外部APIの仕様変更により、APIキーが必要になったため対応。
全てのStayWatch APIエンドポイント呼び出しにX-API-Keyヘッダーを追加し、
設定ファイルからAPIキーを読み込むように修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)