### PR TITLE
Docker設定をマルチステージビルドに変更し、開発環境と本番環境を分離

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -23,6 +23,7 @@ services:
     image: mysql:8.4
     volumes:
       - ./docker/db/my.cnf:/etc/mysql/conf.d/my.cnf
+      - mysql_data:/var/lib/mysql
     ports:
       - ${MYSQL_PORT}:3306
     environment:
@@ -35,3 +36,7 @@ services:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       timeout: 20s
       retries: 5
+
+volumes:
+  mysql_data:
+    driver: local

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -4,11 +4,11 @@ services:
     build:
       context: .
       dockerfile: ./docker/app/dockerfile
-      target: development  # 開発環境用ステージを指定
+      target: production  # 本番環境用ステージを指定
     stdin_open: true
     tty: true
     volumes:
-      - ./src:/stay_watch-slackbot/src
+      # ソースコードのマウントは不要（バイナリが埋め込まれている）
       - ./log:/stay_watch-slackbot/log
     environment:
       - GIN_MODE=${GIN_MODE}

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -5,6 +5,7 @@ services:
       context: .
       dockerfile: ./docker/app/dockerfile
       target: production  # 本番環境用ステージを指定
+    restart: unless-stopped
     stdin_open: true
     tty: true
     volumes:
@@ -21,6 +22,7 @@ services:
   db:
     container_name: ${MYSQL_CONTAINER_NAME}
     image: mysql:8.4
+    restart: unless-stopped
     volumes:
       - ./docker/db/my.cnf:/etc/mysql/conf.d/my.cnf
       - mysql_data:/var/lib/mysql

--- a/compose.yml
+++ b/compose.yml
@@ -23,6 +23,7 @@ services:
     image: mysql:8.4
     volumes:
       - ./docker/db/my.cnf:/etc/mysql/conf.d/my.cnf
+      - mysql_data:/var/lib/mysql
     ports:
       - ${MYSQL_PORT}:3306
     environment:
@@ -35,3 +36,7 @@ services:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       timeout: 20s
       retries: 5
+
+volumes:
+  mysql_data:
+    driver: local

--- a/docker/app/dockerfile
+++ b/docker/app/dockerfile
@@ -1,11 +1,43 @@
-FROM golang:1.25.4
+# 開発環境ステージ (air を使用)
+FROM golang:1.25.4 AS development
 
-RUN apt update && apt install -y git &&\
-    apt install -y lsof &&\
+RUN apt update && apt install -y git lsof &&\
     go install github.com/air-verse/air@latest
 
 WORKDIR /stay_watch-slackbot/src
 
-# COPY ./src /root/src
-
 CMD ["air", "-c", ".air.toml"]
+
+# ============================================
+
+# ビルドステージ (バイナリをコンパイル)
+FROM golang:1.25.4 AS builder
+
+WORKDIR /stay_watch-slackbot/src
+
+# 依存関係をコピーしてダウンロード
+COPY ./src/go.mod ./src/go.sum ./
+RUN go mod download
+
+# ソースコードをコピー
+COPY ./src .
+
+# バイナリをビルド
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/main .
+
+# ============================================
+
+# 本番環境ステージ (コンパイル済みバイナリを実行)
+FROM alpine:latest AS production
+
+RUN apk --no-cache add ca-certificates tzdata
+
+WORKDIR /app
+
+# ビルドステージからバイナリをコピー
+COPY --from=builder /app/main .
+
+# ログディレクトリを作成
+RUN mkdir -p /stay_watch-slackbot/log
+
+CMD ["./main"]


### PR DESCRIPTION
## Summary

Docker設定を改善し、開発環境と本番環境を適切に分離しました。

- **マルチステージビルドの導入**: Dockerfileを3ステージ構成に変更（development / builder / production）
- **本番環境用設定の追加**: `compose.prod.yml` を新規作成し、本番環境専用の設定を分離
- **データベースの永続化**: MySQLデータを名前付きボリュームで永続化
- **自動再起動の設定**: 本番環境でのコンテナ自動再起動を設定

## Changes

### docker/app/dockerfile
- マルチステージビルドに変更
  - `development`: air によるホットリロード環境（開発用）
  - `builder`: Go バイナリのコンパイル（ビルド専用）
  - `production`: Alpine ベースの軽量な本番環境

### compose.yml
- `target: development` を追加し、開発環境用ステージを明示的に指定
- `mysql_data` ボリュームを追加してデータベースを永続化

### compose.prod.yml（新規作成）
- `target: production` を指定し、本番環境用ステージを使用
- `restart: unless-stopped` を設定し、コンテナの自動再起動を有効化
- `mysql_data` ボリュームでデータベースを永続化
- ソースコードのマウントを除外（バイナリが埋め込まれているため不要）

## Benefits

### 開発環境
- air による高速な開発サイクルを維持
- ホットリロードで快適な開発体験

### 本番環境
- 最適化されたコンパイル済みバイナリで高速起動
- Alpine ベースで軽量なイメージサイズ
- サーバー再起動時に自動的にコンテナが起動
- データベースの永続化により、データ損失を防止

## Test plan

- [ ] 開発環境での動作確認: `docker compose up --build`
- [ ] 本番環境での動作確認: `docker compose -f compose.prod.yml up --build`
- [ ] データベースの永続化確認: コンテナ再作成後もデータが保持されることを確認
- [ ] 自動再起動の確認: コンテナ停止後の自動再起動を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)