### PR TITLE
feat: Type/Tool/Status登録APIとEvent登録の拡張

### DIFF
--- a/src/controller/slack_command.go
+++ b/src/controller/slack_command.go
@@ -33,30 +33,88 @@ func PostRegisterEventCommand(c *gin.Context) {
 		respondError(c, http.StatusBadRequest, "bad request")
 		return
 	}
+
+	// Type一覧を取得
+	types, err := service.GetTypes()
+	if err != nil {
+		log.Printf("Error getting types: %v", err)
+		respondError(c, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	var typeOptions []*slack.OptionBlockObject
+	for _, t := range types {
+		option := slack.OptionBlockObject{
+			Text:  slack.NewTextBlockObject("plain_text", t.Name, false, false),
+			Value: fmt.Sprintf("%d", t.ID),
+		}
+		typeOptions = append(typeOptions, &option)
+	}
+
+	// Tool一覧を取得
+	tools, err := service.GetTools()
+	if err != nil {
+		log.Printf("Error getting tools: %v", err)
+		respondError(c, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	var toolOptions []*slack.OptionBlockObject
+	for _, tool := range tools {
+		option := slack.OptionBlockObject{
+			Text:  slack.NewTextBlockObject("plain_text", tool.Name, false, false),
+			Value: fmt.Sprintf("%d", tool.ID),
+		}
+		toolOptions = append(toolOptions, &option)
+	}
+
+	blocks := []slack.Block{
+		// 名前
+		slack.NewInputBlock(
+			"name_block",
+			slack.NewTextBlockObject("plain_text", "話題を入力してください", false, false),
+			slack.NewTextBlockObject("plain_text", "名前", false, false),
+			slack.NewPlainTextInputBlockElement(slack.NewTextBlockObject("plain_text", "例：スマブラ、Android", false, false), "name_input"),
+		),
+		// 人数
+		slack.NewInputBlock(
+			"number_block",
+			slack.NewTextBlockObject("plain_text", "最低限必要な人数を入力してください", false, false),
+			slack.NewTextBlockObject("plain_text", "人数", false, false),
+			slack.NewPlainTextInputBlockElement(slack.NewTextBlockObject("plain_text", "例：2", false, false), "number_input"),
+		),
+	}
+
+	// Type選択を追加（Typeが存在する場合）
+	if len(typeOptions) > 0 {
+		blocks = append(blocks, slack.NewInputBlock(
+			"type_block",
+			slack.NewTextBlockObject("plain_text", "タイプを選択してください", false, false),
+			slack.NewTextBlockObject("plain_text", "タイプ", false, false),
+			slack.NewOptionsSelectBlockElement(slack.OptTypeStatic, slack.NewTextBlockObject("plain_text", "タイプを選択", false, false), "type_select", typeOptions...),
+		))
+	}
+
+	// Tool選択を追加（Toolが存在する場合）
+	if len(toolOptions) > 0 {
+		blocks = append(blocks, &slack.InputBlock{
+			Type:    slack.MBTInput,
+			BlockID: "tool_block",
+			Label:   slack.NewTextBlockObject("plain_text", "使用するツールを選択してください（複数選択可）", false, false),
+			Element: slack.NewCheckboxGroupsBlockElement("tool_checkbox", toolOptions...),
+			Optional: true,
+		})
+	}
+
 	modalRequest := slack.ModalViewRequest{
-		Type:       slack.ViewType("modal"),
-		Title:      slack.NewTextBlockObject("plain_text", "登録フォーム", false, false),
-		Submit:     slack.NewTextBlockObject("plain_text", "送信", false, false),
+		Type:            slack.ViewType("modal"),
+		Title:           slack.NewTextBlockObject("plain_text", "登録フォーム", false, false),
+		Submit:          slack.NewTextBlockObject("plain_text", "送信", false, false),
 		PrivateMetadata: s.ResponseURL,
-		Close:      slack.NewTextBlockObject("plain_text", "閉じる", false, false),
-		CallbackID: "register_event",
+		Close:           slack.NewTextBlockObject("plain_text", "閉じる", false, false),
+		CallbackID:      "register_event",
 		Blocks: slack.Blocks{
-			BlockSet: []slack.Block{
-				// 名前
-				slack.NewInputBlock(
-					"name_block",
-					slack.NewTextBlockObject("plain_text", "話題を入力してください", false, false),
-					slack.NewTextBlockObject("plain_text", "名前", false, false),
-					slack.NewPlainTextInputBlockElement(slack.NewTextBlockObject("plain_text", "例：スマブラ、Android", false, false), "name_input"),
-				),
-				// 人数
-				slack.NewInputBlock(
-					"number_block",
-					slack.NewTextBlockObject("plain_text", "最低限必要な人数を入力してください", false, false),
-					slack.NewTextBlockObject("plain_text", "人数", false, false),
-					slack.NewPlainTextInputBlockElement(slack.NewTextBlockObject("plain_text", "例：2", false, false), "number_input"),
-				),
-			},
+			BlockSet: blocks,
 		},
 	}
 	_, err = api.OpenView(s.TriggerID, modalRequest)

--- a/src/controller/slack_command.go
+++ b/src/controller/slack_command.go
@@ -117,3 +117,48 @@ func PostRegisterCorrespondCommand(c *gin.Context) {
 	}
 	respondSlackSuccess(c, "モーダルを開きました。")
 }
+
+func PostRegisterTypeCommand(c *gin.Context) {
+	text := c.PostForm("text")
+
+	_, err := service.RegisterType(text)
+	if err != nil {
+		if err.Error() == "type already exists" {
+			respondSlackError(c, fmt.Sprintf("Type %s already exists.", text))
+			return
+		}
+		respondSlackError(c, fmt.Sprintf("Error: %s", err.Error()))
+		return
+	}
+	respondSlackSuccess(c, fmt.Sprintf("Type %s registered successfully.", text))
+}
+
+func PostRegisterToolCommand(c *gin.Context) {
+	text := c.PostForm("text")
+
+	_, err := service.RegisterTool(text)
+	if err != nil {
+		if err.Error() == "tool already exists" {
+			respondSlackError(c, fmt.Sprintf("Tool %s already exists.", text))
+			return
+		}
+		respondSlackError(c, fmt.Sprintf("Error: %s", err.Error()))
+		return
+	}
+	respondSlackSuccess(c, fmt.Sprintf("Tool %s registered successfully.", text))
+}
+
+func PostRegisterStatusCommand(c *gin.Context) {
+	text := c.PostForm("text")
+
+	_, err := service.RegisterStatus(text)
+	if err != nil {
+		if err.Error() == "status already exists" {
+			respondSlackError(c, fmt.Sprintf("Status %s already exists.", text))
+			return
+		}
+		respondSlackError(c, fmt.Sprintf("Error: %s", err.Error()))
+		return
+	}
+	respondSlackSuccess(c, fmt.Sprintf("Status %s registered successfully.", text))
+}

--- a/src/controller/slack_interaction.go
+++ b/src/controller/slack_interaction.go
@@ -79,8 +79,36 @@ func PostSlackInteraction(c *gin.Context) {
 			return
 		}
 
+		// TypeIDを取得
+		var typeID uint = 0
+		if typeBlock, ok := values["type_block"]; ok {
+			if typeSelect, ok := typeBlock["type_select"]; ok && typeSelect.SelectedOption.Value != "" {
+				typeIDInt, err := strconv.Atoi(typeSelect.SelectedOption.Value)
+				if err != nil {
+					respondError(c, http.StatusBadRequest, "type id must be an integer")
+					return
+				}
+				typeID = uint(typeIDInt)
+			}
+		}
+
+		// ToolIDsを取得
+		var toolIDs []uint
+		if toolBlock, ok := values["tool_block"]; ok {
+			if toolCheckbox, ok := toolBlock["tool_checkbox"]; ok {
+				for _, opt := range toolCheckbox.SelectedOptions {
+					toolIDInt, err := strconv.Atoi(opt.Value)
+					if err != nil {
+						respondError(c, http.StatusBadRequest, "tool id must be an integer")
+						return
+					}
+					toolIDs = append(toolIDs, uint(toolIDInt))
+				}
+			}
+		}
+
 		// DB登録などの処理
-		if _, err := service.RegisterEvent(name, numInt); err != nil {
+		if _, err := service.RegisterEvent(name, numInt, typeID, toolIDs); err != nil {
 			if err.Error() == "event already exists" {
 				api.PostMessage(
 					"",

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -48,6 +48,9 @@ func Router() {
 	r.POST("/slack/command/add_user", controller.PostRegisterUserCommand)
 	r.POST("/slack/command/add_event", controller.PostRegisterEventCommand)
 	r.POST("/slack/command/add_correspond", controller.PostRegisterCorrespondCommand)
+	r.POST("/slack/command/add_type", controller.PostRegisterTypeCommand)
+	r.POST("/slack/command/add_tool", controller.PostRegisterToolCommand)
+	r.POST("/slack/command/add_status", controller.PostRegisterStatusCommand)
 	r.GET("/notification", controller.SendDM)
 
 	r.Run(":8085")

--- a/src/service/event.go
+++ b/src/service/event.go
@@ -7,11 +7,27 @@ import (
 	"github.com/kajiLabTeam/stay-watch-slackbot/model"
 )
 
-func RegisterEvent(name string, minNumber int) (model.Event, error) {
+func RegisterEvent(name string, minNumber int, typeID uint, toolIDs []uint) (model.Event, error) {
 	event := model.Event{
 		Name:      name,
 		MinNumber: minNumber,
+		TypeID:    typeID,
 	}
+
+	// Toolsを取得してeventに関連付ける
+	if len(toolIDs) > 0 {
+		var tools []model.Tool
+		for _, id := range toolIDs {
+			tool := model.Tool{}
+			tool.ID = id
+			if err := tool.ReadByID(); err != nil {
+				return event, err
+			}
+			tools = append(tools, tool)
+		}
+		event.Tools = tools
+	}
+
 	if err := event.Create(); err != nil {
 		// MySQLのユニーク制約エラー（1062）を型安全に判定
 		var mysqlErr *mysql.MySQLError

--- a/src/service/status.go
+++ b/src/service/status.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"errors"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/kajiLabTeam/stay-watch-slackbot/model"
+)
+
+func RegisterStatus(name string) (model.Status, error) {
+	status := model.Status{
+		Name: name,
+	}
+	if err := status.Create(); err != nil {
+		// MySQLのユニーク制約エラー（1062）を型安全に判定
+		var mysqlErr *mysql.MySQLError
+		if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+			return status, errors.New("status already exists")
+		}
+		return status, err
+	}
+	return status, nil
+}
+
+func GetStatuses() ([]model.Status, error) {
+	var s model.Status
+	statuses, err := s.ReadAll()
+	if err != nil {
+		return statuses, err
+	}
+	return statuses, nil
+}

--- a/src/service/tool.go
+++ b/src/service/tool.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"errors"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/kajiLabTeam/stay-watch-slackbot/model"
+)
+
+func RegisterTool(name string) (model.Tool, error) {
+	tool := model.Tool{
+		Name: name,
+	}
+	if err := tool.Create(); err != nil {
+		// MySQLのユニーク制約エラー（1062）を型安全に判定
+		var mysqlErr *mysql.MySQLError
+		if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+			return tool, errors.New("tool already exists")
+		}
+		return tool, err
+	}
+	return tool, nil
+}
+
+func GetTools() ([]model.Tool, error) {
+	var t model.Tool
+	tools, err := t.ReadAll()
+	if err != nil {
+		return tools, err
+	}
+	return tools, nil
+}

--- a/src/service/type.go
+++ b/src/service/type.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"errors"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/kajiLabTeam/stay-watch-slackbot/model"
+)
+
+func RegisterType(name string) (model.Type, error) {
+	typeObj := model.Type{
+		Name: name,
+	}
+	if err := typeObj.Create(); err != nil {
+		// MySQLのユニーク制約エラー（1062）を型安全に判定
+		var mysqlErr *mysql.MySQLError
+		if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+			return typeObj, errors.New("type already exists")
+		}
+		return typeObj, err
+	}
+	return typeObj, nil
+}
+
+func GetTypes() ([]model.Type, error) {
+	var t model.Type
+	types, err := t.ReadAll()
+	if err != nil {
+		return types, err
+	}
+	return types, nil
+}


### PR DESCRIPTION
## Summary
- Type、Tool、Status登録用のSlack APIエンドポイントを追加
- Event登録モーダルにType選択とTool選択機能を追加

## 主な変更内容
### 1. Type、Tool、Status登録API
- 各エンティティのサービス層を実装（`service/type.go`, `service/tool.go`, `service/status.go`）
- Slackコマンドハンドラーを追加（`PostRegisterTypeCommand`, `PostRegisterToolCommand`, `PostRegisterStatusCommand`）
- 新規エンドポイントを追加（`/slack/command/add_type`, `/slack/command/add_tool`, `/slack/command/add_status`）
- MySQLユニーク制約エラーのハンドリングを実装

### 2. Event登録の拡張
- Event登録モーダルにType選択フィールドを追加（単一選択）
- Event登録モーダルにTool選択フィールドを追加（複数選択可、オプション）
- `RegisterEvent`関数を更新してTypeIDとToolIDsを受け取るように変更
- Interaction handlerでTypeとToolsの選択値を取得して処理

## Test plan
- [ ] Type登録APIが正常に動作することを確認（`/slack/command/add_type`）
- [ ] Tool登録APIが正常に動作することを確認（`/slack/command/add_tool`）
- [ ] Status登録APIが正常に動作することを確認（`/slack/command/add_status`）
- [ ] Event登録モーダルでTypeとToolが選択できることを確認
- [ ] Event登録時にTypeとToolsが正しくデータベースに保存されることを確認
- [ ] 重複登録時に適切なエラーメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)