### PR TITLE
fix: slack_command.goのフォーマット修正

### DIFF
--- a/src/controller/slack_command.go
+++ b/src/controller/slack_command.go
@@ -98,10 +98,10 @@ func PostRegisterEventCommand(c *gin.Context) {
 	// Tool選択を追加（Toolが存在する場合）
 	if len(toolOptions) > 0 {
 		blocks = append(blocks, &slack.InputBlock{
-			Type:    slack.MBTInput,
-			BlockID: "tool_block",
-			Label:   slack.NewTextBlockObject("plain_text", "使用するツールを選択してください（複数選択可）", false, false),
-			Element: slack.NewCheckboxGroupsBlockElement("tool_checkbox", toolOptions...),
+			Type:     slack.MBTInput,
+			BlockID:  "tool_block",
+			Label:    slack.NewTextBlockObject("plain_text", "使用するツールを選択してください（複数選択可）", false, false),
+			Element:  slack.NewCheckboxGroupsBlockElement("tool_checkbox", toolOptions...),
 			Optional: true,
 		})
 	}


### PR DESCRIPTION
- InputBlock構造体のフィールドアラインメントを修正
- gofmtに準拠した形式に修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)