### PR TITLE
feat: Event登録にType/Tool選択機能を追加

### DIFF
--- a/src/controller/slack_interaction.go
+++ b/src/controller/slack_interaction.go
@@ -79,8 +79,36 @@ func PostSlackInteraction(c *gin.Context) {
 			return
 		}
 
+		// TypeIDを取得
+		var typeID uint = 0
+		if typeBlock, ok := values["type_block"]; ok {
+			if typeSelect, ok := typeBlock["type_select"]; ok && typeSelect.SelectedOption.Value != "" {
+				typeIDInt, err := strconv.Atoi(typeSelect.SelectedOption.Value)
+				if err != nil {
+					respondError(c, http.StatusBadRequest, "type id must be an integer")
+					return
+				}
+				typeID = uint(typeIDInt)
+			}
+		}
+
+		// ToolIDsを取得
+		var toolIDs []uint
+		if toolBlock, ok := values["tool_block"]; ok {
+			if toolCheckbox, ok := toolBlock["tool_checkbox"]; ok {
+				for _, opt := range toolCheckbox.SelectedOptions {
+					toolIDInt, err := strconv.Atoi(opt.Value)
+					if err != nil {
+						respondError(c, http.StatusBadRequest, "tool id must be an integer")
+						return
+					}
+					toolIDs = append(toolIDs, uint(toolIDInt))
+				}
+			}
+		}
+
 		// DB登録などの処理
-		if _, err := service.RegisterEvent(name, numInt); err != nil {
+		if _, err := service.RegisterEvent(name, numInt, typeID, toolIDs); err != nil {
 			if err.Error() == "event already exists" {
 				api.PostMessage(
 					"",

--- a/src/service/event.go
+++ b/src/service/event.go
@@ -7,11 +7,27 @@ import (
 	"github.com/kajiLabTeam/stay-watch-slackbot/model"
 )
 
-func RegisterEvent(name string, minNumber int) (model.Event, error) {
+func RegisterEvent(name string, minNumber int, typeID uint, toolIDs []uint) (model.Event, error) {
 	event := model.Event{
 		Name:      name,
 		MinNumber: minNumber,
+		TypeID:    typeID,
 	}
+
+	// Toolsを取得してeventに関連付ける
+	if len(toolIDs) > 0 {
+		var tools []model.Tool
+		for _, id := range toolIDs {
+			tool := model.Tool{}
+			tool.ID = id
+			if err := tool.ReadByID(); err != nil {
+				return event, err
+			}
+			tools = append(tools, tool)
+		}
+		event.Tools = tools
+	}
+
 	if err := event.Create(); err != nil {
 		// MySQLのユニーク制約エラー（1062）を型安全に判定
 		var mysqlErr *mysql.MySQLError

--- a/src/service/status.go
+++ b/src/service/status.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"errors"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/kajiLabTeam/stay-watch-slackbot/model"
+)
+
+func RegisterStatus(name string) (model.Status, error) {
+	status := model.Status{
+		Name: name,
+	}
+	if err := status.Create(); err != nil {
+		// MySQLのユニーク制約エラー（1062）を型安全に判定
+		var mysqlErr *mysql.MySQLError
+		if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+			return status, errors.New("status already exists")
+		}
+		return status, err
+	}
+	return status, nil
+}
+
+func GetStatuses() ([]model.Status, error) {
+	var s model.Status
+	statuses, err := s.ReadAll()
+	if err != nil {
+		return statuses, err
+	}
+	return statuses, nil
+}

--- a/src/service/tool.go
+++ b/src/service/tool.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"errors"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/kajiLabTeam/stay-watch-slackbot/model"
+)
+
+func RegisterTool(name string) (model.Tool, error) {
+	tool := model.Tool{
+		Name: name,
+	}
+	if err := tool.Create(); err != nil {
+		// MySQLのユニーク制約エラー（1062）を型安全に判定
+		var mysqlErr *mysql.MySQLError
+		if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+			return tool, errors.New("tool already exists")
+		}
+		return tool, err
+	}
+	return tool, nil
+}
+
+func GetTools() ([]model.Tool, error) {
+	var t model.Tool
+	tools, err := t.ReadAll()
+	if err != nil {
+		return tools, err
+	}
+	return tools, nil
+}

--- a/src/service/type.go
+++ b/src/service/type.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"errors"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/kajiLabTeam/stay-watch-slackbot/model"
+)
+
+func RegisterType(name string) (model.Type, error) {
+	typeObj := model.Type{
+		Name: name,
+	}
+	if err := typeObj.Create(); err != nil {
+		// MySQLのユニーク制約エラー（1062）を型安全に判定
+		var mysqlErr *mysql.MySQLError
+		if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+			return typeObj, errors.New("type already exists")
+		}
+		return typeObj, err
+	}
+	return typeObj, nil
+}
+
+func GetTypes() ([]model.Type, error) {
+	var t model.Type
+	types, err := t.ReadAll()
+	if err != nil {
+		return types, err
+	}
+	return types, nil
+}


### PR DESCRIPTION
## Summary
Event登録モーダルにType選択とTool選択機能を追加し、より詳細なイベント情報を登録できるようにしました。

## 背景
- PR #13でこの機能が追加されましたが、PR #14でrevertされました
- PR #15ではREST API変更のみがマージされ、Event登録機能の拡張は含まれていませんでした
- このPRで改めてEvent登録にType/Tool選択機能を追加します

## 変更内容

### 1. Event登録モーダルの拡張
- **Type選択フィールド**を追加（単一選択）
  - 登録済みのTypeから選択可能
  - Typeが未登録の場合はフィールドを非表示
- **Tool選択フィールド**を追加（複数選択可、オプション）
  - 登録済みのToolから複数選択可能
  - Toolが未登録の場合はフィールドを非表示

### 2. サービス層の更新
- `RegisterEvent`関数のシグネチャを更新
  - 引数に`typeID uint`と`toolIDs []uint`を追加
  - EventにTypeとToolsを関連付ける処理を実装

### 3. Interaction handlerの更新
- モーダルからTypeIDとToolIDsを取得する処理を追加
- 取得した値をRegisterEvent関数に渡すように修正

### 4. サービス層ファイルの追加
- `service/type.go` - Type登録・取得機能
- `service/tool.go` - Tool登録・取得機能
- `service/status.go` - Status登録・取得機能
- これらはPR #15で追加されたAPI (controller/api.go) が依存していますが、mainブランチに欠落していました

## 影響範囲
- Event登録機能を使用しているユーザー
  - モーダルにType/Tool選択フィールドが追加されます
  - 既存のEvent登録機能は引き続き動作します（後方互換性あり）

## Test plan
- [ ] Event登録モーダルでTypeが選択できることを確認
- [ ] Event登録モーダルでToolsが複数選択できることを確認
- [ ] Type未登録時にType選択フィールドが非表示になることを確認
- [ ] Tool未登録時にTool選択フィールドが非表示になることを確認
- [ ] 選択したTypeとToolsがEventに正しく関連付けられることを確認
- [ ] 既存のEvent登録機能（Type/Toolなし）が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)