### PR TITLE
Type/Tool/Statusの登録をバッチ登録のみに統一

### DIFF
--- a/src/controller/api.go
+++ b/src/controller/api.go
@@ -7,43 +7,19 @@ import (
 	"github.com/kajiLabTeam/stay-watch-slackbot/service"
 )
 
-// RegisterTypeRequest はType登録のリクエストボディ
-type RegisterTypeRequest struct {
-	Name string `json:"name" binding:"required"`
+// BatchRegisterTypeRequest はType一括登録のリクエストボディ
+type RegisterTypesRequest struct {
+	Names []string `json:"names" binding:"required,min=1"`
 }
 
-// RegisterToolRequest はTool登録のリクエストボディ
-type RegisterToolRequest struct {
-	Name string `json:"name" binding:"required"`
+// BatchRegisterToolRequest はTool一括登録のリクエストボディ
+type RegisterToolsRequest struct {
+	Names []string `json:"names" binding:"required,min=1"`
 }
 
-// RegisterStatusRequest はStatus登録のリクエストボディ
-type RegisterStatusRequest struct {
-	Name string `json:"name" binding:"required"`
-}
-
-// PostRegisterType はTypeを登録するAPIハンドラー
-func PostRegisterType(c *gin.Context) {
-	var req RegisterTypeRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondError(c, http.StatusBadRequest, "invalid request body")
-		return
-	}
-
-	typeObj, err := service.RegisterType(req.Name)
-	if err != nil {
-		if err.Error() == "type already exists" {
-			respondError(c, http.StatusConflict, "type already exists")
-			return
-		}
-		respondError(c, http.StatusInternalServerError, err.Error())
-		return
-	}
-
-	c.JSON(http.StatusCreated, gin.H{
-		"message": "type registered successfully",
-		"data":    typeObj,
-	})
+// BatchRegisterStatusRequest はStatus一括登録のリクエストボディ
+type RegisterStatusesRequest struct {
+	Names []string `json:"names" binding:"required,min=1"`
 }
 
 // GetTypes はType一覧を取得するAPIハンドラー
@@ -56,30 +32,6 @@ func GetTypes(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"data": types,
-	})
-}
-
-// PostRegisterTool はToolを登録するAPIハンドラー
-func PostRegisterTool(c *gin.Context) {
-	var req RegisterToolRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondError(c, http.StatusBadRequest, "invalid request body")
-		return
-	}
-
-	tool, err := service.RegisterTool(req.Name)
-	if err != nil {
-		if err.Error() == "tool already exists" {
-			respondError(c, http.StatusConflict, "tool already exists")
-			return
-		}
-		respondError(c, http.StatusInternalServerError, err.Error())
-		return
-	}
-
-	c.JSON(http.StatusCreated, gin.H{
-		"message": "tool registered successfully",
-		"data":    tool,
 	})
 }
 
@@ -96,30 +48,6 @@ func GetTools(c *gin.Context) {
 	})
 }
 
-// PostRegisterStatus はStatusを登録するAPIハンドラー
-func PostRegisterStatus(c *gin.Context) {
-	var req RegisterStatusRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondError(c, http.StatusBadRequest, "invalid request body")
-		return
-	}
-
-	status, err := service.RegisterStatus(req.Name)
-	if err != nil {
-		if err.Error() == "status already exists" {
-			respondError(c, http.StatusConflict, "status already exists")
-			return
-		}
-		respondError(c, http.StatusInternalServerError, err.Error())
-		return
-	}
-
-	c.JSON(http.StatusCreated, gin.H{
-		"message": "status registered successfully",
-		"data":    status,
-	})
-}
-
 // GetStatuses はStatus一覧を取得するAPIハンドラー
 func GetStatuses(c *gin.Context) {
 	statuses, err := service.GetStatuses()
@@ -130,5 +58,68 @@ func GetStatuses(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"data": statuses,
+	})
+}
+
+// PostRegisterTypes はTypeを一括登録するAPIハンドラー
+func PostRegisterTypes(c *gin.Context) {
+	var req RegisterTypesRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	types, errors, err := service.BatchRegisterTypes(req.Names)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"message": "batch registration completed",
+		"data":    types,
+		"errors":  errors,
+	})
+}
+
+// Post	RegisterTools はToolを一括登録するAPIハンドラー
+func PostRegisterTools(c *gin.Context) {
+	var req RegisterToolsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	tools, errors, err := service.BatchRegisterTools(req.Names)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"message": "batch registration completed",
+		"data":    tools,
+		"errors":  errors,
+	})
+}
+
+// PostRegisterStatuses はStatusを一括登録するAPIハンドラー
+func PostRegisterStatuses(c *gin.Context) {
+	var req RegisterStatusesRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	statuses, errors, err := service.BatchRegisterStatuses(req.Names)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"message": "batch registration completed",
+		"data":    statuses,
+		"errors":  errors,
 	})
 }

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -52,11 +52,11 @@ func Router() {
 	r.GET("/notification", controller.SendDM)
 
 	// REST API endpoints
-	r.POST("/api/types", controller.PostRegisterType)
+	r.POST("/api/types", controller.PostRegisterTypes)
 	r.GET("/api/types", controller.GetTypes)
-	r.POST("/api/tools", controller.PostRegisterTool)
+	r.POST("/api/tools", controller.PostRegisterTools)
 	r.GET("/api/tools", controller.GetTools)
-	r.POST("/api/statuses", controller.PostRegisterStatus)
+	r.POST("/api/statuses", controller.PostRegisterStatuses)
 	r.GET("/api/statuses", controller.GetStatuses)
 
 	r.Run(":8085")

--- a/src/service/status.go
+++ b/src/service/status.go
@@ -30,3 +30,20 @@ func GetStatuses() ([]model.Status, error) {
 	}
 	return statuses, nil
 }
+
+// BatchRegisterStatuses は複数のStatusを一括登録する
+func BatchRegisterStatuses(names []string) ([]model.Status, map[string]string, error) {
+	var statuses []model.Status
+	errors := make(map[string]string)
+
+	for _, name := range names {
+		status, err := RegisterStatus(name)
+		if err != nil {
+			errors[name] = err.Error()
+			continue
+		}
+		statuses = append(statuses, status)
+	}
+
+	return statuses, errors, nil
+}

--- a/src/service/tool.go
+++ b/src/service/tool.go
@@ -30,3 +30,20 @@ func GetTools() ([]model.Tool, error) {
 	}
 	return tools, nil
 }
+
+// BatchRegisterTools は複数のToolを一括登録する
+func BatchRegisterTools(names []string) ([]model.Tool, map[string]string, error) {
+	var tools []model.Tool
+	errors := make(map[string]string)
+
+	for _, name := range names {
+		tool, err := RegisterTool(name)
+		if err != nil {
+			errors[name] = err.Error()
+			continue
+		}
+		tools = append(tools, tool)
+	}
+
+	return tools, errors, nil
+}

--- a/src/service/type.go
+++ b/src/service/type.go
@@ -30,3 +30,20 @@ func GetTypes() ([]model.Type, error) {
 	}
 	return types, nil
 }
+
+// BatchRegisterTypes は複数のTypeを一括登録する
+func BatchRegisterTypes(names []string) ([]model.Type, map[string]string, error) {
+	var types []model.Type
+	errors := make(map[string]string)
+
+	for _, name := range names {
+		typeObj, err := RegisterType(name)
+		if err != nil {
+			errors[name] = err.Error()
+			continue
+		}
+		types = append(types, typeObj)
+	}
+
+	return types, errors, nil
+}


### PR DESCRIPTION
## Summary
- 単一登録エンドポイントを削除し、バッチ登録APIに統一
- リクエスト形式を `{"name": "..."}` から `{"names": [...]}` に変更
- エンドポイントパスをシンプル化（`/api/types/batch` → `/api/types`）

## Changes
### Controller (controller/api.go)
- `PostRegisterType` → `PostRegisterTypes`（バッチ専用）
- `PostRegisterTool` → `PostRegisterTools`（バッチ専用）
- `PostRegisterStatus` → `PostRegisterStatuses`（バッチ専用）
- リクエスト構造体を `RegisterTypesRequest` など配列を受け取る形式に変更

### Router (router/router.go)
- `POST /api/types` - バッチ登録エンドポイントに統一
- `POST /api/tools` - バッチ登録エンドポイントに統一
- `POST /api/statuses` - バッチ登録エンドポイントに統一

### Service
- `BatchRegisterTypes` - 複数Typeを一括登録
- `BatchRegisterTools` - 複数Toolを一括登録
- `BatchRegisterStatuses` - 複数Statusを一括登録
- 部分的な失敗を許容し、errorsマップで失敗した項目を返却

## Test plan
- [ ] バッチ登録APIで複数項目を一括登録できることを確認
- [ ] 重複エラーが発生した場合、成功した項目とエラーが返却されることを確認
- [ ] バリデーションエラー（空配列など）が適切にハンドリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)