### PR TITLE
fix: 本番環境でログファイルが作成されない問題を修正

### DIFF
--- a/docker/app/dockerfile
+++ b/docker/app/dockerfile
@@ -32,12 +32,13 @@ FROM alpine:latest AS production
 
 RUN apk --no-cache add ca-certificates tzdata
 
-WORKDIR /app
-
-# ビルドステージからバイナリをコピー
-COPY --from=builder /app/main .
+# 開発環境と同じディレクトリ構成にする
+WORKDIR /stay_watch-slackbot/src
 
 # ログディレクトリを作成
 RUN mkdir -p /stay_watch-slackbot/log
+
+# ビルドステージからバイナリをコピー
+COPY --from=builder /app/main .
 
 CMD ["./main"]

--- a/src/controller/slack_dm.go
+++ b/src/controller/slack_dm.go
@@ -14,7 +14,7 @@ import (
 
 func SendDM(c *gin.Context) {
 	// ログファイルを開く
-	logFile, err := os.OpenFile("log/dm_send.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	logFile, err := os.OpenFile("../log/dm_send.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "failed to open log file")
 		return


### PR DESCRIPTION
## Summary
- 本番環境(compose.prod.yml)でコンテナ起動時にlogディレクトリにログファイルが作成されない問題を修正
- DockerfileのWORKDIRが開発環境と異なっていたため、相対パスが正しく解決されていなかった

## Changes
- `docker/app/dockerfile`: 本番ステージのWORKDIRを `/app` から `/stay_watch-slackbot/src` に変更
- `src/controller/slack_dm.go`: ログパスを `log/dm_send.log` から `../log/dm_send.log` に統一

## Test plan
- [ ] `docker compose -f compose.prod.yml build --no-cache` でビルド
- [ ] `docker compose -f compose.prod.yml up -d` で起動
- [ ] `./log/` ディレクトリにログファイルが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)