### PR TITLE
feat: イベントの発生確率を取得するAPIを追加

### DIFF
--- a/src/router/router.go
+++ b/src/router/router.go
@@ -58,6 +58,7 @@ func Router() {
 	r.GET("/api/tools", controller.GetTools)
 	r.POST("/api/statuses", controller.PostRegisterStatuses)
 	r.GET("/api/statuses", controller.GetStatuses)
+	r.GET("/api/events/:id/probability", controller.GetEventProbability)
 
 	r.Run(":8085")
 }

--- a/src/service/activity.go
+++ b/src/service/activity.go
@@ -14,8 +14,8 @@ type ActivityTimeRange struct {
 	End   string // "HH:MM"
 }
 
-// getActivityProbability イベントごとの活動確率を取得する
-func getActivityProbability(eventID uint, dayOfWeek time.Weekday, targetTime string) (float64, error) {
+// GetActivityProbability イベントごとの活動確率を取得する
+func GetActivityProbability(eventID uint, dayOfWeek time.Weekday, targetTime string) (float64, error) {
 	// 1. ログを取得
 	logs, weeks, err := model.ReadLogsByEventIDAndDayOfWeek(eventID, dayOfWeek)
 	if err != nil || len(logs) == 0 {

--- a/src/service/notification.go
+++ b/src/service/notification.go
@@ -38,7 +38,7 @@ func NotifyByEvent(targetWeekday time.Weekday) ([]model.User, map[int]map[int][]
 	// Step 2: 各イベントに対して処理
 	for _, event := range events {
 		// Step 2a: 活動確率を取得（閾値チェック）
-		probability, err := getActivityProbability(event.ID, targetWeekday, "23:59")
+		probability, err := GetActivityProbability(event.ID, targetWeekday, "23:59")
 		if err != nil || probability < 0.30 {
 			continue // 確率が閾値未満の場合スキップ
 		}


### PR DESCRIPTION
## Summary
- 指定した曜日とイベントから発生確率を取得するREST APIを追加
- 既存の`getActivityProbability`関数を公開関数化して再利用

## API仕様

**エンドポイント:** `GET /api/events/:id/probability`

| パラメータ | 種類 | 必須 | 説明 |
|-----------|------|------|------|
| `id` | パス | ○ | イベントID |
| `weekday` | クエリ | ○ | 曜日 (0-6, 月曜=0, 日曜=6) |
| `time` | クエリ | - | 対象時刻 ("HH:MM"形式、デフォルト:現在時刻) |

**レスポンス例:**
```json
{
  "event_id": 1,
  "weekday": 0,
  "time": "12:00",
  "probability": 0.75
}
```

## Test plan
- [ ] `curl "http://localhost:8085/api/events/1/probability?weekday=0&time=12:00"` でレスポンス確認
- [ ] weekdayパラメータなしで400エラーを確認
- [ ] 不正なevent_idで400エラーを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)