### PR TITLE
fix: weekdayパラメータをMySQL WEEKDAY形式に統一

### DIFF
--- a/src/controller/slack_dm.go
+++ b/src/controller/slack_dm.go
@@ -32,13 +32,14 @@ func SendDM(c *gin.Context) {
 		tomorrow := time.Now().In(loc).AddDate(0, 0, 1)
 		targetWeekday = tomorrow.Weekday()
 	} else {
-		// パラメータから曜日を解析（int型として）
+		// パラメータから曜日を解析（MySQL WEEKDAY形式: 月=0, 日=6）
 		weekdayInt, err := strconv.Atoi(weekdayParam)
 		if err != nil || weekdayInt < 0 || weekdayInt > 6 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid weekday parameter. Use integer 0-6 (0=Sunday, 1=Monday, ..., 6=Saturday)"})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid weekday parameter. Use integer 0-6 (0=Monday, ..., 6=Sunday)"})
 			return
 		}
-		targetWeekday = time.Weekday(weekdayInt)
+		// MySQL WEEKDAY形式(月=0)からGoのtime.Weekday形式(日=0)に変換
+		targetWeekday = time.Weekday((weekdayInt + 1) % 7)
 	}
 
 	users, userMessages := service.NotifyByEvent(targetWeekday)


### PR DESCRIPTION
/notificationと/api/events/:id/probabilityで同じ形式を使用
- 0=Monday, 1=Tuesday, ..., 6=Sunday