### PR TITLE
feat: 同日の重複ログを排除した確率計算機能を追加

### DIFF
--- a/src/lib/time_utils.go
+++ b/src/lib/time_utils.go
@@ -33,3 +33,12 @@ func MinutesToTime(minutes int) string {
 	mins := minutes % 60
 	return fmt.Sprintf("%02d:%02d", hours, mins)
 }
+
+// ExtractTimeFromDatetime "YYYY-MM-DD HH:MM"形式の日時文字列から時刻部分を抽出する
+func ExtractTimeFromDatetime(datetimeStr string) (string, error) {
+	parts := strings.SplitN(datetimeStr, " ", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid datetime format: %s", datetimeStr)
+	}
+	return parts[1], nil
+}

--- a/src/prediction/probability.go
+++ b/src/prediction/probability.go
@@ -57,8 +57,8 @@ func GetProbability(data []string, time string, weeks int) (float64, error) {
 			continue
 		}
 
-		// 2-1. クラスタ中心（平均）
-		loc := c.Center
+		// 2-1. クラスタ平均
+		loc := stat.Mean(c.Data, nil)
 
 		// 2-2. クラスタの標準偏差を計算
 		scale := stat.StdDev(c.Data, nil)
@@ -112,6 +112,15 @@ func GetProbabilityByUniqueDate(data []string, time string, weeks int) (float64,
 	uniqueTimes := make([]string, 0, len(dateToTime))
 	for _, t := range dateToTime {
 		uniqueTimes = append(uniqueTimes, t)
+	}
+
+	// 日付ありのデータで確率から日付なしのデータに変換して計算
+	for i, datetimeStr := range uniqueTimes {
+		timeStr, err := lib.ExtractTimeFromDatetime(datetimeStr)
+		if err != nil {
+			return 0, err
+		}
+		uniqueTimes[i] = timeStr
 	}
 
 	// 既存のGetProbability関数を使用して確率を計算

--- a/src/prediction/probability.go
+++ b/src/prediction/probability.go
@@ -2,6 +2,7 @@ package prediction
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kajiLabTeam/stay-watch-slackbot/lib"
 	"gonum.org/v1/gonum/stat"
@@ -83,6 +84,38 @@ func GetProbability(data []string, time string, weeks int) (float64, error) {
 	}
 
 	return totalProbability, nil
+}
+
+// GetProbabilityByUniqueDate 来訪確率を計算する（日付重複を排除）
+// 同じ日に複数のログがある場合、最初の時刻のみを使用する
+// data: "2006-01-02 15:04"形式の日付時刻文字列スライス
+// time: "HH:MM"形式の時刻文字列
+// weeks: 週数
+func GetProbabilityByUniqueDate(data []string, time string, weeks int) (float64, error) {
+	// 日付ごとに最初の時刻のみを保持
+	dateToTime := make(map[string]string)
+	for _, d := range data {
+		parts := strings.SplitN(d, " ", 2)
+		if len(parts) != 2 {
+			return 0, fmt.Errorf("invalid datetime format: %s", d)
+		}
+		date := parts[0]
+		timeStr := parts[1]
+
+		// 同じ日付がまだ登録されていない場合のみ追加
+		if _, exists := dateToTime[date]; !exists {
+			dateToTime[date] = timeStr
+		}
+	}
+
+	// 重複排除後の時刻リストを作成
+	uniqueTimes := make([]string, 0, len(dateToTime))
+	for _, t := range dateToTime {
+		uniqueTimes = append(uniqueTimes, t)
+	}
+
+	// 既存のGetProbability関数を使用して確率を計算
+	return GetProbability(uniqueTimes, time, weeks)
 }
 
 // GetMostLikelyTime 活動の最も可能性の高い時間を見つける

--- a/src/service/activity.go
+++ b/src/service/activity.go
@@ -22,21 +22,21 @@ func GetActivityProbability(eventID uint, dayOfWeek time.Weekday, targetTime str
 		return 0.0, nil // データ不足時は 0.0 を返す
 	}
 
-	// 2. Status が "start" のログをフィルタリング
-	var timeStrings []string
+	// 2. Status が "start" のログをフィルタリング（日付付き）
+	var datetimeStrings []string
 	for _, log := range logs {
 		if log.Status.Name == "start" {
-			timeStr := log.CreatedAt.Format("15:04")
-			timeStrings = append(timeStrings, timeStr)
+			datetimeStr := log.CreatedAt.Format("2006-01-02 15:04")
+			datetimeStrings = append(datetimeStrings, datetimeStr)
 		}
 	}
 
-	if len(timeStrings) == 0 {
+	if len(datetimeStrings) == 0 {
 		return 0.0, nil
 	}
 
-	// 3. prediction パッケージで確率計算
-	probability, err := prediction.GetProbability(timeStrings, targetTime, weeks)
+	// 3. prediction パッケージで確率計算（日付重複を排除）
+	probability, err := prediction.GetProbabilityByUniqueDate(datetimeStrings, targetTime, weeks)
 	if err != nil {
 		return 0.0, err
 	}


### PR DESCRIPTION
## Summary
- 同じ日に同じイベントのログが複数記録された場合に発生確率が実際より高くなる問題を修正
- `GetProbabilityByUniqueDate`関数を追加し、日付ごとに重複を排除して確率計算
- `/api/events/:id/probability`エンドポイントに適用

## Test plan
- [ ] 同じ日に複数ログがある場合、1回としてカウントされることを確認
- [ ] APIレスポンスの確率が正しく計算されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)