### PR TITLE
refactor: 週数計算をmodel層からservice層に移動

### DIFF
--- a/src/model/log.go
+++ b/src/model/log.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -49,7 +48,7 @@ func ReadLogsByEventIDAndDateRange(eventID uint, startDate, endDate time.Time) (
 }
 
 // ReadLogsByEventIDAndDayOfWeek retrieves logs by event ID and day of week
-func ReadLogsByEventIDAndDayOfWeek(eventID uint, dayOfWeek time.Weekday) ([]Log, int, error) {
+func ReadLogsByEventIDAndDayOfWeek(eventID uint, dayOfWeek time.Weekday) ([]Log, error) {
 	var logs []Log
 
 	// dayOfWeekをMysqlのWEEKDAY関数に合わせて変換 (0=月曜日, ..., 6=日曜日)
@@ -60,20 +59,10 @@ func ReadLogsByEventIDAndDayOfWeek(eventID uint, dayOfWeek time.Weekday) ([]Log,
 		Preload("Event").
 		Preload("Status").
 		Find(&logs).Error; err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
-	// 週数を計算
-	var weeks int
-	dateMap := make(map[string]bool)
-	for _, log := range logs {
-		year, week := log.CreatedAt.ISOWeek()
-		key := fmt.Sprintf("%d-%d", year, week)
-		dateMap[key] = true
-	}
-	weeks = len(dateMap)
-
-	return logs, weeks, nil
+	return logs, nil
 }
 
 // ReadLogsByEventIDAndDayOfWeekWithWeeks retrieves logs by event ID, day of week, and number of weeks


### PR DESCRIPTION
## Summary
- 週数の計算方法を「ログが存在するユニークな週数」から「最初のログから今日までの経過週数」に変更
- 計算ロジックを `model/log.go` から `service/activity.go` に移動
- `ReadLogsByEventIDAndDayOfWeek` の戻り値から週数を削除し、呼び出し元で計算するように変更

## Test plan
- [ ] イベント確率APIが正しく週数を計算して返すことを確認
- [ ] 活動時間範囲の予測が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)