### PR TITLE
refactor: DB・内部処理をUTC準拠に変更

### DIFF
--- a/src/controller/slack_dm.go
+++ b/src/controller/slack_dm.go
@@ -27,9 +27,9 @@ func SendDM(c *gin.Context) {
 
 	var targetWeekday time.Weekday
 	if weekdayParam == "" {
-		// パラメータが指定されていない場合は翌日
-		loc, _ := time.LoadLocation("Asia/Tokyo")
-		tomorrow := time.Now().In(loc).AddDate(0, 0, 1)
+		// パラメータが指定されていない場合は翌日（JSTベース）
+		jst := time.FixedZone("JST", 9*60*60)
+		tomorrow := time.Now().In(jst).AddDate(0, 0, 1)
 		targetWeekday = tomorrow.Weekday()
 	} else {
 		// パラメータから曜日を解析（MySQL WEEKDAY形式: 月=0, 日=6）
@@ -91,8 +91,8 @@ func SendDM(c *gin.Context) {
 			respondError(c, http.StatusInternalServerError, "failed to send message")
 		} else {
 			// 送信成功時にログを記録
-			loc, _ := time.LoadLocation("Asia/Tokyo")
-			now := time.Now().In(loc)
+			jst := time.FixedZone("JST", 9*60*60)
+			now := time.Now().UTC().In(jst)
 			logger.Printf("[%s] 送信先: %s (SlackID: %s)\n推奨活動内容:\n%s\n---\n",
 				now.Format("2006-01-02 15:04:05"),
 				user.Name,

--- a/src/lib/sql.go
+++ b/src/lib/sql.go
@@ -25,7 +25,7 @@ func SQLConnect() (database *gorm.DB) {
 	protocol := getEnv("MYSQL_PROTOCOL", "")
 	dbname := getEnv("MYSQL_DBNAME", "")
 
-	dsn := fmt.Sprintf("%s:%s@%s/%s?charset=utf8&parseTime=true&loc=Asia%%2FTokyo",
+	dsn := fmt.Sprintf("%s:%s@%s/%s?charset=utf8&parseTime=true&loc=UTC",
 		user, password, protocol, dbname)
 	dialector := mysql.Open(dsn)
 	// log.Default().Println(dsn)

--- a/src/lib/time_utils.go
+++ b/src/lib/time_utils.go
@@ -5,7 +5,40 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
+
+// JST は日本標準時（表示用、固定）
+var JST = time.FixedZone("JST", 9*60*60)
+
+// StayWatchTimezone はStayWatch APIが使用するタイムゾーン
+// TODO: StayWatchがUTCに移行したら time.UTC に変更する
+var StayWatchTimezone = time.FixedZone("JST", 9*60*60)
+
+// ToJST はUTC時刻をJSTに変換する（Slack表示用）
+func ToJST(t time.Time) time.Time {
+	return t.In(JST)
+}
+
+// FormatTimeJST はUTC時刻をJSTの"HH:MM"形式に変換する（Slack表示用）
+func FormatTimeJST(t time.Time) string {
+	return ToJST(t).Format("15:04")
+}
+
+// ToStayWatchTime はUTC時刻をStayWatchのタイムゾーンに変換する
+func ToStayWatchTime(t time.Time) time.Time {
+	return t.In(StayWatchTimezone)
+}
+
+// FormatForStayWatch はUTC時刻をStayWatch用の"HH:MM"形式に変換する
+func FormatForStayWatch(t time.Time) string {
+	return ToStayWatchTime(t).Format("15:04")
+}
+
+// FormatDateTimeForStayWatch はUTC時刻をStayWatch用の"2006-01-02 15:04"形式に変換する
+func FormatDateTimeForStayWatch(t time.Time) string {
+	return ToStayWatchTime(t).Format("2006-01-02 15:04")
+}
 
 // TimeToMinutes "HH:MM"形式の時刻を分に変換する
 func TimeToMinutes(timeStr string) (int, error) {

--- a/src/prediction/probability.go
+++ b/src/prediction/probability.go
@@ -46,7 +46,7 @@ func GetProbability(data []string, time string, weeks int) (float64, error) {
 	clusters := Clustering(dataMinutes)
 
 	// 2. 各クラスタの確率を計算
-	var totalProbability float64
+	totalProbability := 0.0
 
 	for _, c := range clusters {
 		// クラスタ内のデータポイントが1つの場合

--- a/src/service/activity.go
+++ b/src/service/activity.go
@@ -25,7 +25,7 @@ func calculateWeeks(logs []model.Log) int {
 			oldestLog = log
 		}
 	}
-	now := time.Now()
+	now := time.Now().UTC()
 	days := int(now.Sub(oldestLog.CreatedAt).Hours() / 24)
 	return (days / 7) + 1
 }
@@ -42,6 +42,7 @@ func GetActivityProbability(eventID uint, dayOfWeek time.Weekday, targetTime str
 	weeks := calculateWeeks(logs)
 
 	// 3. Status が "start" のログをフィルタリング（日付付き）
+	// DBはUTCなのでそのまま使用（targetTimeもUTC）
 	var datetimeStrings []string
 	for _, log := range logs {
 		if log.Status.Name == "start" {
@@ -73,10 +74,11 @@ func getActivityTimeRange(eventID uint, dayOfWeek time.Weekday) (ActivityTimeRan
 	weeks := calculateWeeks(logs)
 
 	// start と end のログを分離
+	// Slack表示用にJSTに変換
 	var startTimes []string
 	var endTimes []string
 	for _, log := range logs {
-		timeStr := log.CreatedAt.Format("15:04")
+		timeStr := lib.FormatTimeJST(log.CreatedAt)
 		switch log.Status.Name {
 		case "start":
 			startTimes = append(startTimes, timeStr)

--- a/src/service/notification.go
+++ b/src/service/notification.go
@@ -38,7 +38,7 @@ func NotifyByEvent(targetWeekday time.Weekday) ([]model.User, map[int]map[int][]
 	// Step 2: 各イベントに対して処理
 	for _, event := range events {
 		// Step 2a: 活動確率を取得（閾値チェック）
-		probability, err := GetActivityProbability(event.ID, targetWeekday, "23:59")
+		probability, err := GetActivityProbability(event.ID, targetWeekday, "08:59")
 		if err != nil || probability < 0.30 {
 			continue // 確率が閾値未満の場合スキップ
 		}

--- a/src/service/slack_event.go
+++ b/src/service/slack_event.go
@@ -26,8 +26,7 @@ func GetProbability(userID int) (Probability, string, error) {
 	}
 
 	var probability Probability
-	loc, _ := time.LoadLocation("Asia/Tokyo")
-	now := time.Now().In(loc)
+	now := time.Now().UTC()
 	timeStr := now.Format("15:04")
 	w := now.Weekday()
 	// 月曜を0とする変換


### PR DESCRIPTION
## Summary
- DB接続・内部処理をUTCベースに変更
- API入力はJSTを受け取り、UTCに変換して内部処理
- Slack表示はJSTで出力
- StayWatch連携用のタイムゾーン設定を分離（将来のUTC移行に対応）

## 変更内容
| 層 | タイムゾーン |
|----|------------|
| DB接続 | UTC |
| 内部計算 | UTC |
| API入力 | JST → UTC変換 |
| Slack表示 | JST |
| StayWatch連携 | JST（将来UTC予定） |

## 変更ファイル
- `lib/time_utils.go` - タイムゾーンユーティリティ追加
- `lib/sql.go` - DB接続をUTCに変更
- `service/slack_event.go`, `service/activity.go`, `service/notification.go` - 内部処理UTC化
- `controller/api.go`, `controller/slack_dm.go` - API入出力のタイムゾーン処理

## Test plan
- [ ] `go build ./...` でビルドエラーがないことを確認
- [ ] 既存機能の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)