### PR TITLE
feat: ログ一括登録API（POST /api/logs）を追加

### DIFF
--- a/src/router/router.go
+++ b/src/router/router.go
@@ -59,6 +59,7 @@ func Router() {
 	r.POST("/api/statuses", controller.PostRegisterStatuses)
 	r.GET("/api/statuses", controller.GetStatuses)
 	r.GET("/api/events/:id/probability", controller.GetEventProbability)
+	r.POST("/api/logs", controller.PostRegisterLogs)
 
 	r.Run(":8085")
 }

--- a/src/service/log.go
+++ b/src/service/log.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kajiLabTeam/stay-watch-slackbot/lib"
+	"github.com/kajiLabTeam/stay-watch-slackbot/model"
+)
+
+// LogEntryInput はログ登録のための入力データを表す
+type LogEntryInput struct {
+	EventID   uint
+	StatusID  uint
+	CreatedAt string // JST形式 "2006-01-02 15:04:05"
+}
+
+// RegisterLog は単一のログを登録する（JST→UTC変換、外部キー検証）
+func RegisterLog(input LogEntryInput) (model.Log, error) {
+	// Event存在確認
+	event := model.Event{}
+	event.ID = input.EventID
+	if err := event.ReadByID(); err != nil {
+		return model.Log{}, fmt.Errorf("event_id %d not found", input.EventID)
+	}
+
+	// Status存在確認
+	status := model.Status{}
+	status.ID = input.StatusID
+	if err := status.ReadByID(); err != nil {
+		return model.Log{}, fmt.Errorf("status_id %d not found", input.StatusID)
+	}
+
+	// JST時刻をパースしてUTCに変換
+	createdAtJST, err := time.ParseInLocation("2006-01-02 15:04:05", input.CreatedAt, lib.JST)
+	if err != nil {
+		return model.Log{}, fmt.Errorf("invalid created_at format: %s", input.CreatedAt)
+	}
+	createdAtUTC := createdAtJST.UTC()
+
+	// ログを作成
+	log := model.Log{
+		EventID:  input.EventID,
+		StatusID: input.StatusID,
+	}
+	// CreatedAtを手動で設定するためにgorm.Modelを直接操作
+	log.CreatedAt = createdAtUTC
+
+	if err := log.Create(); err != nil {
+		return model.Log{}, err
+	}
+
+	return log, nil
+}
+
+// BatchRegisterLogs は複数のログを一括登録する
+func BatchRegisterLogs(inputs []LogEntryInput) ([]model.Log, map[string]string, error) {
+	var logs []model.Log
+	errors := make(map[string]string)
+
+	for i, input := range inputs {
+		log, err := RegisterLog(input)
+		if err != nil {
+			errors[fmt.Sprintf("%d", i)] = err.Error()
+			continue
+		}
+		logs = append(logs, log)
+	}
+
+	return logs, errors, nil
+}


### PR DESCRIPTION
## Summary
- 外部システムからPOSTリクエストで複数のログを一括受信するAPIを実装
- JST形式の日時をUTCに変換してDBに保存
- event_id, status_idの外部キー検証を実施
- 部分成功対応（エラーはインデックスをキーに返却）

## Test plan
- [ ] `go build` でビルド確認
- [ ] `curl -X POST http://localhost:8085/api/logs -H "Content-Type: application/json" -d '{"logs":[{"event_id":2,"status_id":1,"created_at":"2025-11-24 17:40:26"}]}'` でAPI動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)