### PR TITLE
feat: 全活動の時間帯別発生確率APIを追加

### DIFF
--- a/src/controller/api.go
+++ b/src/controller/api.go
@@ -249,6 +249,44 @@ func GetEventProbability(c *gin.Context) {
 	})
 }
 
+// GetAllActivityProbabilities は全活動の1時間ごとの発生確率を取得するAPIハンドラー
+// @Summary 全活動の時間帯別発生確率を取得
+// @Tags activities
+// @Produce json
+// @Param weekday query int false "曜日 (MySQL WEEKDAY形式: 0=月, 6=日)。省略時は今日の曜日"
+// @Success 200 {object} map[string]interface{}
+// @Failure 400 {object} map[string]interface{}
+// @Failure 500 {object} map[string]interface{}
+// @Router /api/activities/probabilities [get]
+func GetAllActivityProbabilities(c *gin.Context) {
+	jst := time.FixedZone("JST", 9*60*60)
+	var weekday time.Weekday
+
+	weekdayStr := c.Query("weekday")
+	if weekdayStr == "" {
+		// デフォルト: 今日の曜日（JST）
+		weekday = time.Now().In(jst).Weekday()
+	} else {
+		weekdayInt, err := strconv.Atoi(weekdayStr)
+		if err != nil || weekdayInt < 0 || weekdayInt > 6 {
+			respondError(c, http.StatusBadRequest, "weekday must be 0-6 (Monday=0, Sunday=6)")
+			return
+		}
+		// MySQL WEEKDAY形式(月=0)からGoのtime.Weekday形式(日=0)に変換
+		weekday = time.Weekday((weekdayInt + 1) % 7)
+	}
+
+	results, err := service.GetAllActivityProbabilities(weekday)
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"data": results,
+	})
+}
+
 // PostRegisterLogs はログを一括登録するAPIハンドラー
 // @Summary ログを一括登録
 // @Tags logs

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -65,6 +65,7 @@ func Router() {
 	r.POST("/api/statuses", controller.PostRegisterStatuses)
 	r.GET("/api/statuses", controller.GetStatuses)
 	r.GET("/api/events/:id/probability", controller.GetEventProbability)
+	r.GET("/api/activities/probabilities", controller.GetAllActivityProbabilities)
 	r.POST("/api/logs", controller.PostRegisterLogs)
 
 	_ = r.Run(":8085")

--- a/src/service/activity.go
+++ b/src/service/activity.go
@@ -1,12 +1,19 @@
 package service
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/kajiLabTeam/stay-watch-slackbot/lib"
 	"github.com/kajiLabTeam/stay-watch-slackbot/model"
 	"github.com/kajiLabTeam/stay-watch-slackbot/prediction"
 )
+
+// ActivityProbability は活動名と1時間ごとの発生確率を表す
+type ActivityProbability struct {
+	ActivityName  string    `json:"activity_name"`
+	Probabilities []float64 `json:"probabilities"` // length 24, index = hour (0-23 JST), value = 0.0〜1.0
+}
 
 // ActivityTimeRange は活動の予測時間帯を表す
 type ActivityTimeRange struct {
@@ -160,6 +167,75 @@ func filterByCommonActivities(candidates []model.User, receiverActivityEventIDs 
 	}
 
 	return filtered
+}
+
+// GetAllActivityProbabilities は全活動の1時間ごとの発生確率を取得する
+// 各時間帯（JST 0〜23時）の中央（HH:30）を基準に確率を計算する
+func GetAllActivityProbabilities(dayOfWeek time.Weekday) ([]ActivityProbability, error) {
+	// 全イベントを取得
+	event := model.Event{}
+	events, err := event.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read events: %w", err)
+	}
+
+	jst := lib.JST
+	var results []ActivityProbability
+
+	for _, ev := range events {
+		probabilities := make([]float64, 24)
+
+		// 該当曜日のログを取得
+		logs, err := model.ReadLogsByEventIDAndDayOfWeek(ev.ID, dayOfWeek)
+		if err != nil || len(logs) == 0 {
+			// データなしの場合は全て0.0
+			results = append(results, ActivityProbability{
+				ActivityName:  ev.Name,
+				Probabilities: probabilities,
+			})
+			continue
+		}
+
+		weeks := calculateWeeks(logs)
+
+		// "start" ステータスのログのみ抽出（日付付き）
+		var datetimeStrings []string
+		for _, log := range logs {
+			if log.Status.Name == "start" {
+				datetimeStr := log.CreatedAt.Format("2006-01-02 15:04")
+				datetimeStrings = append(datetimeStrings, datetimeStr)
+			}
+		}
+
+		if len(datetimeStrings) == 0 {
+			results = append(results, ActivityProbability{
+				ActivityName:  ev.Name,
+				Probabilities: probabilities,
+			})
+			continue
+		}
+
+		// 各時間帯（JST 0〜23時）の確率を計算
+		for hour := 0; hour < 24; hour++ {
+			// JST HH:30 をUTCに変換
+			jstTime := time.Date(2000, 1, 1, hour, 30, 0, 0, jst)
+			utcTimeStr := jstTime.UTC().Format("15:04")
+
+			prob, err := prediction.GetProbabilityByUniqueDate(datetimeStrings, utcTimeStr, weeks)
+			if err != nil {
+				probabilities[hour] = 0.0
+				continue
+			}
+			probabilities[hour] = prob
+		}
+
+		results = append(results, ActivityProbability{
+			ActivityName:  ev.Name,
+			Probabilities: probabilities,
+		})
+	}
+
+	return results, nil
 }
 
 // getUserActivityTags はユーザーが登録している活動名のリストを取得する


### PR DESCRIPTION
## Summary
- `GET /api/activities/probabilities` エンドポイントを新規追加
- 全活動の0〜23時（JST）の1時間ごとの発生確率を返す
- クエリパラメータ `weekday`（0=月〜6=日）で曜日指定可能（省略時は今日の曜日）

## レスポンス型
```typescript
type ActivityProbability = {
  activityName: string;
  probabilities: number[]; // length 24, index = hour (0-23 JST), value = 0.0〜1.0
};
```

## 変更ファイル
- `src/controller/api.go` - ハンドラー追加
- `src/service/activity.go` - ビジネスロジック追加
- `src/router/router.go` - ルート登録

## Test plan
- [ ] `GET /api/activities/probabilities` でレスポンスが返ることを確認
- [ ] `weekday` パラメータ指定時に該当曜日の確率が返ることを確認
- [ ] 不正な `weekday` 値で400エラーが返ることを確認
- [ ] ログデータがないイベントは全時間帯0.0で返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)