### PR TITLE
feat: CORSミドルウェアを設定

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
+	github.com/gin-contrib/cors v1.7.6 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.5 // indirect
 	github.com/go-openapi/jsonreference v0.21.5 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -15,6 +15,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
+github.com/gin-contrib/cors v1.7.6 h1:3gQ8GMzs1Ylpf70y8bMw4fVpycXIeX1ZemuSQIsnQQY=
+github.com/gin-contrib/cors v1.7.6/go.mod h1:Ulcl+xN4jel9t1Ry8vqph23a60FwH9xVLd+3ykmTjOk=
 github.com/gin-contrib/gzip v0.0.6 h1:NjcunTcGAj5CO1gn4N8jHOSIeRFHIbn51z6K+xaN4d4=
 github.com/gin-contrib/gzip v0.0.6/go.mod h1:QOJlmV2xmayAjkNS2Y8NQsMneuRShOU/kjovCXNuzzk=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -4,7 +4,9 @@ package router
 import (
 	"io"
 	"os"
+	"time"
 
+	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/kajiLabTeam/stay-watch-slackbot/controller"
 	_ "github.com/kajiLabTeam/stay-watch-slackbot/docs"
@@ -20,31 +22,30 @@ func Router() {
 	r := gin.Default()
 	_ = r.SetTrustedProxies([]string{"127.0.0.1"})
 
-	// r.Use(cors.New(cors.Config{
-	// アクセスを許可したいアクセス元
-	// 	AllowOrigins: []string{
-	// 		"https://",
-	// 		"http://localhost:3000",
-	// 	},
-	// 	// アクセスを許可したいHTTPメソッド(以下の例だとPUTやDELETEはアクセスできません)
-	// 	AllowMethods: []string{
-	// 		"POST",
-	// 	},
-	// 	// 許可したいHTTPリクエストヘッダ
-	// 	AllowHeaders: []string{
-	// 		"Access-Control-Allow-Credentials",
-	// 		"Access-Control-Allow-Headers",
-	// 		"Content-Type",
-	// 		"Content-Length",
-	// 		"Accept-Encoding",
-	// 		"Accept",
-	// 		"Authorization",
-	// 	},
-	// 	// cookieなどの情報を必要とするかどうか
-	// 	AllowCredentials: true,
-	// 	// preflightリクエストの結果をキャッシュする時間
-	// 	MaxAge: 24 * time.Hour,
-	// }))
+	r.Use(cors.New(cors.Config{
+		// アクセスを許可したいアクセス元
+		AllowOrigins: []string{
+			"https://staywatch.kajilab.net",
+			"http://localhost:3000",
+		},
+		// アクセスを許可したいHTTPメソッド
+		AllowMethods: []string{
+			"GET",
+			"POST",
+		},
+		// 許可したいHTTPリクエストヘッダ
+		AllowHeaders: []string{
+			"Content-Type",
+			"Content-Length",
+			"Accept-Encoding",
+			"Accept",
+			"Authorization",
+		},
+		// cookieなどの情報を必要とするかどうか
+		AllowCredentials: true,
+		// preflightリクエストの結果をキャッシュする時間
+		MaxAge: 24 * time.Hour,
+	}))
 
 	// Slack endpoints
 	r.POST("/slack/events", controller.PostSlackEvents)


### PR DESCRIPTION
## Summary
- コメントアウトされていたCORS設定を有効化
- `gin-contrib/cors` パッケージを追加
- 許可オリジン: `https://staywatch.kajilab.net`, `http://localhost:3000`
- 許可メソッド: `GET`, `POST`

## Test plan
- [ ] ローカル環境（localhost:3000）からのリクエストがCORSエラーなく通ることを確認
- [ ] 本番環境（staywatch.kajilab.net）からのリクエストが通ることを確認
- [ ] 許可されていないオリジンからのリクエストがブロックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)