### PR TITLE
refactor: Cognitive Complexityの削減

### DIFF
--- a/src/controller/helper.go
+++ b/src/controller/helper.go
@@ -7,6 +7,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const msgInternalServerError = "internal server error"
+
 // respondError は統一されたエラーレスポンスを返す
 func respondError(c *gin.Context, statusCode int, message string) {
 	c.JSON(statusCode, gin.H{"error": message})

--- a/src/controller/slack_command.go
+++ b/src/controller/slack_command.go
@@ -38,7 +38,7 @@ func PostRegisterEventCommand(c *gin.Context) {
 	types, err := service.GetTypes()
 	if err != nil {
 		log.Printf("Error getting types: %v", err)
-		respondError(c, http.StatusInternalServerError, "internal server error")
+		respondError(c, http.StatusInternalServerError, msgInternalServerError)
 		return
 	}
 
@@ -55,7 +55,7 @@ func PostRegisterEventCommand(c *gin.Context) {
 	tools, err := service.GetTools()
 	if err != nil {
 		log.Printf("Error getting tools: %v", err)
-		respondError(c, http.StatusInternalServerError, "internal server error")
+		respondError(c, http.StatusInternalServerError, msgInternalServerError)
 		return
 	}
 
@@ -120,7 +120,7 @@ func PostRegisterEventCommand(c *gin.Context) {
 	_, err = api.OpenView(s.TriggerID, modalRequest)
 	if err != nil {
 		log.Printf("Error opening view: %v", err)
-		respondError(c, http.StatusInternalServerError, "internal server error")
+		respondError(c, http.StatusInternalServerError, msgInternalServerError)
 		return
 	}
 	respondSlackSuccess(c, "モーダルを開きました。")
@@ -136,7 +136,7 @@ func PostRegisterCorrespondCommand(c *gin.Context) {
 
 	events, err := service.GetEvents()
 	if err != nil {
-		respondError(c, http.StatusInternalServerError, "internal server error")
+		respondError(c, http.StatusInternalServerError, msgInternalServerError)
 		return
 	}
 
@@ -170,7 +170,7 @@ func PostRegisterCorrespondCommand(c *gin.Context) {
 	_, err = api.OpenView(s.TriggerID, modalRequest)
 	if err != nil {
 		log.Printf("Error opening view: %v", err)
-		respondError(c, http.StatusInternalServerError, "internal server error")
+		respondError(c, http.StatusInternalServerError, msgInternalServerError)
 		return
 	}
 	respondSlackSuccess(c, "モーダルを開きました。")

--- a/src/controller/slack_dm.go
+++ b/src/controller/slack_dm.go
@@ -1,19 +1,21 @@
 package controller
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/kajiLabTeam/stay-watch-slackbot/model"
 	"github.com/kajiLabTeam/stay-watch-slackbot/service"
 	"github.com/slack-go/slack"
 )
 
 func SendDM(c *gin.Context) {
-	// ログファイルを開く
 	logFile, err := os.OpenFile("../log/dm_send.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "failed to open log file")
@@ -22,24 +24,10 @@ func SendDM(c *gin.Context) {
 	defer func() { _ = logFile.Close() }()
 	logger := log.New(logFile, "", 0)
 
-	// クエリパラメータから曜日を取得（デフォルトは翌日）
-	weekdayParam := c.DefaultQuery("weekday", "")
-
-	var targetWeekday time.Weekday
-	if weekdayParam == "" {
-		// パラメータが指定されていない場合は翌日（JSTベース）
-		jst := time.FixedZone("JST", 9*60*60)
-		tomorrow := time.Now().In(jst).AddDate(0, 0, 1)
-		targetWeekday = tomorrow.Weekday()
-	} else {
-		// パラメータから曜日を解析（MySQL WEEKDAY形式: 月=0, 日=6）
-		weekdayInt, err := strconv.Atoi(weekdayParam)
-		if err != nil || weekdayInt < 0 || weekdayInt > 6 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid weekday parameter. Use integer 0-6 (0=Monday, ..., 6=Sunday)"})
-			return
-		}
-		// MySQL WEEKDAY形式(月=0)からGoのtime.Weekday形式(日=0)に変換
-		targetWeekday = time.Weekday((weekdayInt + 1) % 7)
+	targetWeekday, err := parseTargetWeekday(c.DefaultQuery("weekday", ""))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid weekday parameter. Use integer 0-6 (0=Monday, ..., 6=Sunday)"})
+		return
 	}
 
 	users, userMessages := service.NotifyByEvent(targetWeekday)
@@ -53,51 +41,72 @@ func SendDM(c *gin.Context) {
 		return
 	}
 	for _, user := range users {
-		// ユーザー専用のメッセージを取得
-		eventMessages, hasMessages := userMessages[int(user.ID)]
-		if !hasMessages || len(eventMessages) == 0 {
-			continue
-		}
+		sendDMToUser(c, logger, user, userMessages)
+	}
+}
 
-		channel, _, _, err := api.OpenConversation(&slack.OpenConversationParameters{
-			ReturnIM: true,
-			Users:    []string{user.SlackID},
-		})
-		// log.Default().Println("user", user.SlackID)
-		// log.Default().Println("channel", channel.ID)
-		if err != nil {
-			respondError(c, http.StatusInternalServerError, "failed to open conversation")
-		}
-		message := ""
-		cos := user.Corresponds
-		if len(cos) == 0 {
+func parseTargetWeekday(param string) (time.Weekday, error) {
+	if param == "" {
+		jst := time.FixedZone("JST", 9*60*60)
+		tomorrow := time.Now().In(jst).AddDate(0, 0, 1)
+		return tomorrow.Weekday(), nil
+	}
+	weekdayInt, err := strconv.Atoi(param)
+	if err != nil || weekdayInt < 0 || weekdayInt > 6 {
+		return 0, fmt.Errorf("invalid weekday: %s", param)
+	}
+	return time.Weekday((weekdayInt + 1) % 7), nil
+}
+
+func buildMessageForUser(eventMessages map[int][]string, corresponds []model.Correspond) string {
+	var b strings.Builder
+	for _, co := range corresponds {
+		m, ok := eventMessages[int(co.EventID)]
+		if !ok {
 			continue
 		}
-		for _, co := range cos {
-			// ユーザー専用メッセージからイベントIDでメッセージを取得
-			m, ok := eventMessages[int(co.EventID)]
-			if !ok {
-				continue
-			}
-			for _, v := range m {
-				message += v + "\n"
-			}
-		}
-		if message == "" {
-			continue
-		}
-		_, _, err = api.PostMessage(channel.ID, slack.MsgOptionText(message, false))
-		if err != nil {
-			respondError(c, http.StatusInternalServerError, "failed to send message")
-		} else {
-			// 送信成功時にログを記録
-			jst := time.FixedZone("JST", 9*60*60)
-			now := time.Now().UTC().In(jst)
-			logger.Printf("[%s] 送信先: %s (SlackID: %s)\n推奨活動内容:\n%s\n---\n",
-				now.Format("2006-01-02 15:04:05"),
-				user.Name,
-				user.SlackID,
-				message)
+		for _, v := range m {
+			b.WriteString(v)
+			b.WriteByte('\n')
 		}
 	}
+	return b.String()
+}
+
+func sendDMToUser(c *gin.Context, logger *log.Logger, user model.User, userMessages map[int]map[int][]string) {
+	eventMessages, hasMessages := userMessages[int(user.ID)]
+	if !hasMessages || len(eventMessages) == 0 {
+		return
+	}
+	if len(user.Corresponds) == 0 {
+		return
+	}
+
+	channel, _, _, err := api.OpenConversation(&slack.OpenConversationParameters{
+		ReturnIM: true,
+		Users:    []string{user.SlackID},
+	})
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "failed to open conversation")
+		return
+	}
+
+	message := buildMessageForUser(eventMessages, user.Corresponds)
+	if message == "" {
+		return
+	}
+
+	_, _, err = api.PostMessage(channel.ID, slack.MsgOptionText(message, false))
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, "failed to send message")
+		return
+	}
+
+	jst := time.FixedZone("JST", 9*60*60)
+	now := time.Now().UTC().In(jst)
+	logger.Printf("[%s] 送信先: %s (SlackID: %s)\n推奨活動内容:\n%s\n---\n",
+		now.Format("2006-01-02 15:04:05"),
+		user.Name,
+		user.SlackID,
+		message)
 }

--- a/src/controller/slack_event.go
+++ b/src/controller/slack_event.go
@@ -23,7 +23,7 @@ func PostSlackEvents(c *gin.Context) {
 		return
 	}
 	if _, err := sv.Write(body); err != nil {
-		respondError(c, http.StatusInternalServerError, "internal server error")
+		respondError(c, http.StatusInternalServerError, msgInternalServerError)
 		return
 	}
 	if err := sv.Ensure(); err != nil {
@@ -32,7 +32,7 @@ func PostSlackEvents(c *gin.Context) {
 	}
 	eventsAPIEvent, err := slackevents.ParseEvent(json.RawMessage(body), slackevents.OptionNoVerifyToken())
 	if err != nil {
-		respondError(c, http.StatusInternalServerError, "internal server error")
+		respondError(c, http.StatusInternalServerError, msgInternalServerError)
 		return
 	}
 
@@ -40,7 +40,7 @@ func PostSlackEvents(c *gin.Context) {
 		var r *slackevents.ChallengeResponse
 		err := json.Unmarshal([]byte(body), &r)
 		if err != nil {
-			respondError(c, http.StatusInternalServerError, "internal server error")
+			respondError(c, http.StatusInternalServerError, msgInternalServerError)
 			return
 		}
 		c.Header("Content-Type", "text/plain")
@@ -55,7 +55,7 @@ func PostSlackEvents(c *gin.Context) {
 			obo, err := service.GetUsers()
 			if err != nil {
 				if _, _, err := api.PostMessage(ev.Channel, slack.MsgOptionText("Sorry, I can't get the data.", false)); err != nil {
-					respondError(c, http.StatusInternalServerError, "internal server error")
+					respondError(c, http.StatusInternalServerError, msgInternalServerError)
 				}
 				return
 			}
@@ -81,7 +81,7 @@ func PostSlackEvents(c *gin.Context) {
 				},
 			))
 			if err != nil {
-				respondError(c, http.StatusInternalServerError, "internal server error")
+				respondError(c, http.StatusInternalServerError, msgInternalServerError)
 				return
 			}
 			return

--- a/src/controller/slack_interaction.go
+++ b/src/controller/slack_interaction.go
@@ -19,135 +19,163 @@ func PostSlackInteraction(c *gin.Context) {
 		return
 	}
 
-	// --- Block Actionの処理 ---
 	if len(interaction.ActionCallback.BlockActions) > 0 {
-		action := interaction.ActionCallback.BlockActions[0]
-
-		switch action.ActionID {
-		case "select_user":
-			userID, err := strconv.Atoi(action.SelectedOption.Value)
-			if err != nil {
-				respondError(c, http.StatusBadRequest, "invalid user id")
-				return
-			}
-
-			probability, time, err := service.GetProbability(userID)
-			if err != nil {
-				_, _, _, _ = api.SendMessage(
-					"",
-					slack.MsgOptionReplaceOriginal(interaction.ResponseURL),
-					slack.MsgOptionText("Sorry, I can't get the data.", false),
-				)
-				return
-			}
-
-			p := probability.Probability * 100
-			_, _, _, _ = api.SendMessage(
-				"",
-				slack.MsgOptionReplaceOriginal(interaction.ResponseURL),
-				slack.MsgOptionBlocks(
-					slack.SectionBlock{
-						Type: slack.MBTSection,
-						Text: &slack.TextBlockObject{
-							Type: slack.MarkdownType,
-							Text: "だれの確率を調べますか？: " + action.SelectedOption.Text.Text,
-						},
-					},
-					slack.SectionBlock{
-						Type: slack.MBTSection,
-						Text: &slack.TextBlockObject{
-							Type: slack.MarkdownType,
-							Text: "```\n" + probability.UserName + "が" + time + "までに研究室に来る確率 : " + strconv.FormatFloat(p, 'f', 2, 64) + "% ```",
-						},
-					},
-				),
-			)
-			return
-		}
+		handleBlockAction(c, interaction)
+		return
 	}
 
-	// --- モーダルSubmitの処理 ---
-	if interaction.Type == slack.InteractionTypeViewSubmission && interaction.View.CallbackID == "register_event" {
-		values := interaction.View.State.Values
-		responseURL := interaction.View.PrivateMetadata
-		name := values["name_block"]["name_input"].Value
-		numStr := values["number_block"]["number_input"].Value
+	if interaction.Type == slack.InteractionTypeViewSubmission {
+		handleViewSubmission(c, interaction)
+		return
+	}
 
-		numInt, err := strconv.Atoi(numStr)
+	c.JSON(http.StatusOK, gin.H{})
+}
+
+func handleBlockAction(c *gin.Context, interaction slack.InteractionCallback) {
+	action := interaction.ActionCallback.BlockActions[0]
+
+	switch action.ActionID {
+	case "select_user":
+		handleSelectUser(c, interaction, action)
+	}
+}
+
+func handleSelectUser(c *gin.Context, interaction slack.InteractionCallback, action *slack.BlockAction) {
+	userID, err := strconv.Atoi(action.SelectedOption.Value)
+	if err != nil {
+		respondError(c, http.StatusBadRequest, "invalid user id")
+		return
+	}
+
+	probability, time, err := service.GetProbability(userID)
+	if err != nil {
+		_, _, _, _ = api.SendMessage(
+			"",
+			slack.MsgOptionReplaceOriginal(interaction.ResponseURL),
+			slack.MsgOptionText("Sorry, I can't get the data.", false),
+		)
+		return
+	}
+
+	p := probability.Probability * 100
+	_, _, _, _ = api.SendMessage(
+		"",
+		slack.MsgOptionReplaceOriginal(interaction.ResponseURL),
+		slack.MsgOptionBlocks(
+			slack.SectionBlock{
+				Type: slack.MBTSection,
+				Text: &slack.TextBlockObject{
+					Type: slack.MarkdownType,
+					Text: "だれの確率を調べますか？: " + action.SelectedOption.Text.Text,
+				},
+			},
+			slack.SectionBlock{
+				Type: slack.MBTSection,
+				Text: &slack.TextBlockObject{
+					Type: slack.MarkdownType,
+					Text: "```\n" + probability.UserName + "が" + time + "までに研究室に来る確率 : " + strconv.FormatFloat(p, 'f', 2, 64) + "% ```",
+				},
+			},
+		),
+	)
+}
+
+func handleViewSubmission(c *gin.Context, interaction slack.InteractionCallback) {
+	switch interaction.View.CallbackID {
+	case "register_event":
+		handleRegisterEvent(c, interaction)
+	case "select_events":
+		handleSelectEvents(c, interaction)
+	default:
+		c.JSON(http.StatusOK, gin.H{})
+	}
+}
+
+func handleRegisterEvent(c *gin.Context, interaction slack.InteractionCallback) {
+	values := interaction.View.State.Values
+	responseURL := interaction.View.PrivateMetadata
+	name := values["name_block"]["name_input"].Value
+	numStr := values["number_block"]["number_input"].Value
+
+	numInt, err := strconv.Atoi(numStr)
+	if err != nil {
+		respondError(c, http.StatusBadRequest, "number must be an integer")
+		return
+	}
+
+	typeID := parseTypeID(c, values)
+	if typeID == nil {
+		return
+	}
+
+	toolIDs := parseToolIDs(c, values)
+	if toolIDs == nil {
+		return
+	}
+
+	if _, err := service.RegisterEvent(name, numInt, *typeID, toolIDs); err != nil {
+		if err.Error() == "event already exists" {
+			_, _, _ = api.PostMessage("", slack.MsgOptionReplaceOriginal(responseURL), slack.MsgOptionText("登録済みのイベントです", false))
+			return
+		}
+		_, _, _, _ = api.SendMessage("", slack.MsgOptionReplaceOriginal(interaction.ResponseURL), slack.MsgOptionText("Error: "+err.Error(), false))
+		return
+	}
+
+	_, _, _ = api.PostMessage("", slack.MsgOptionReplaceOriginal(responseURL), slack.MsgOptionText("登録が完了しました。", false))
+	c.JSON(http.StatusOK, gin.H{})
+}
+
+func parseTypeID(c *gin.Context, values map[string]map[string]slack.BlockAction) *uint {
+	var typeID uint
+	typeBlock, ok := values["type_block"]
+	if !ok {
+		return &typeID
+	}
+	typeSelect, ok := typeBlock["type_select"]
+	if !ok || typeSelect.SelectedOption.Value == "" {
+		return &typeID
+	}
+	typeIDInt, err := strconv.Atoi(typeSelect.SelectedOption.Value)
+	if err != nil {
+		respondError(c, http.StatusBadRequest, "type id must be an integer")
+		return nil
+	}
+	typeID = uint(typeIDInt)
+	return &typeID
+}
+
+func parseToolIDs(c *gin.Context, values map[string]map[string]slack.BlockAction) []uint {
+	var toolIDs []uint
+	toolBlock, ok := values["tool_block"]
+	if !ok {
+		return toolIDs
+	}
+	toolCheckbox, ok := toolBlock["tool_checkbox"]
+	if !ok {
+		return toolIDs
+	}
+	for _, opt := range toolCheckbox.SelectedOptions {
+		toolIDInt, err := strconv.Atoi(opt.Value)
 		if err != nil {
-			respondError(c, http.StatusBadRequest, "number must be an integer")
-			return
+			respondError(c, http.StatusBadRequest, "tool id must be an integer")
+			return nil
 		}
+		toolIDs = append(toolIDs, uint(toolIDInt))
+	}
+	return toolIDs
+}
 
-		// TypeIDを取得
-		var typeID uint = 0
-		if typeBlock, ok := values["type_block"]; ok {
-			if typeSelect, ok := typeBlock["type_select"]; ok && typeSelect.SelectedOption.Value != "" {
-				typeIDInt, err := strconv.Atoi(typeSelect.SelectedOption.Value)
-				if err != nil {
-					respondError(c, http.StatusBadRequest, "type id must be an integer")
-					return
-				}
-				typeID = uint(typeIDInt)
-			}
-		}
+func handleSelectEvents(c *gin.Context, interaction slack.InteractionCallback) {
+	slackUserID := interaction.User.ID
+	responseURL := interaction.View.PrivateMetadata
+	options := interaction.View.State.Values["event_select_block"]["event_checkbox"].SelectedOptions
 
-		// ToolIDsを取得
-		var toolIDs []uint
-		if toolBlock, ok := values["tool_block"]; ok {
-			if toolCheckbox, ok := toolBlock["tool_checkbox"]; ok {
-				for _, opt := range toolCheckbox.SelectedOptions {
-					toolIDInt, err := strconv.Atoi(opt.Value)
-					if err != nil {
-						respondError(c, http.StatusBadRequest, "tool id must be an integer")
-						return
-					}
-					toolIDs = append(toolIDs, uint(toolIDInt))
-				}
-			}
-		}
-
-		// DB登録などの処理
-		if _, err := service.RegisterEvent(name, numInt, typeID, toolIDs); err != nil {
-			if err.Error() == "event already exists" {
-				_, _, _ = api.PostMessage(
-					"",
-					slack.MsgOptionReplaceOriginal(responseURL),
-					slack.MsgOptionText("登録済みのイベントです", false),
-				)
-				return
-			}
-			_, _, _, _ = api.SendMessage(
-				"",
-				slack.MsgOptionReplaceOriginal(interaction.ResponseURL),
-				slack.MsgOptionText("Error: "+err.Error(), false),
-			)
-			return
-		}
-
-		_, _, _ = api.PostMessage("", slack.MsgOptionReplaceOriginal(responseURL), slack.MsgOptionText("登録が完了しました。", false))
-
-		// 成功レスポンス
-		c.JSON(http.StatusOK, gin.H{})
-		return
+	for _, opt := range options {
+		_, _ = service.RegisterCorrespond(opt.Text.Text, slackUserID)
 	}
 
-	if interaction.Type == slack.InteractionTypeViewSubmission && interaction.View.CallbackID == "select_events" {
-		slackUserID := interaction.User.ID
-		responseURL := interaction.View.PrivateMetadata
-		options := interaction.View.State.Values["event_select_block"]["event_checkbox"].SelectedOptions
-
-		for _, opt := range options {
-			eventName := opt.Text.Text
-			_, _ = service.RegisterCorrespond(eventName, slackUserID)
-		}
-
-		_, _, _ = api.PostMessage("", slack.MsgOptionReplaceOriginal(responseURL), slack.MsgOptionText("登録が完了しました。", false))
-
-		c.JSON(http.StatusOK, gin.H{})
-		return
-	}
-
-	// どの処理にも該当しない場合
+	_, _, _ = api.PostMessage("", slack.MsgOptionReplaceOriginal(responseURL), slack.MsgOptionText("登録が完了しました。", false))
 	c.JSON(http.StatusOK, gin.H{})
 }

--- a/src/go.mod
+++ b/src/go.mod
@@ -3,6 +3,7 @@ module github.com/kajiLabTeam/stay-watch-slackbot
 go 1.25.8
 
 require (
+	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/slack-go/slack v0.17.3
@@ -22,7 +23,6 @@ require (
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
-	github.com/gin-contrib/cors v1.7.6 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.5 // indirect
 	github.com/go-openapi/jsonreference v0.21.5 // indirect

--- a/src/prediction/clustering.go
+++ b/src/prediction/clustering.go
@@ -39,10 +39,30 @@ func (gmm *GaussianMixture) Fit(data []float64) {
 	n := len(data)
 	k := gmm.NComponents
 
-	// K-means++スタイルの初期化
 	gmm.initializeKMeansPlusPlus(data)
+	gmm.initializeVariancesAndWeights(data)
 
-	// 分散と重みを初期化
+	responsibilities := make([][]float64, n)
+	for i := range responsibilities {
+		responsibilities[i] = make([]float64, k)
+	}
+	prevLogLikelihood := math.Inf(-1)
+
+	for iter := 0; iter < gmm.MaxIter; iter++ {
+		gmm.eStep(data, responsibilities)
+		gmm.mStep(data, responsibilities)
+
+		logLikelihood := gmm.logLikelihood(data)
+		if math.Abs(logLikelihood-prevLogLikelihood) < gmm.Tolerance {
+			break
+		}
+		prevLogLikelihood = logLikelihood
+	}
+}
+
+// initializeVariancesAndWeights 分散と重みを初期化する
+func (gmm *GaussianMixture) initializeVariancesAndWeights(data []float64) {
+	k := gmm.NComponents
 	gmm.Variances = make([]float64, k)
 	gmm.Weights = make([]float64, k)
 	dataVar := stat.Variance(data, nil)
@@ -53,65 +73,60 @@ func (gmm *GaussianMixture) Fit(data []float64) {
 		gmm.Variances[i] = dataVar
 		gmm.Weights[i] = 1.0 / float64(k)
 	}
+}
 
-	// EMアルゴリズム
-	// responsibilities[i][j] = データiがクラスタjに属する確率
-	responsibilities := make([][]float64, n)
-	for i := range responsibilities {
-		responsibilities[i] = make([]float64, k)
-	}
-	prevLogLikelihood := math.Inf(-1)
-
-	for iter := 0; iter < gmm.MaxIter; iter++ {
-		// Eステップ: 負担率を計算
-		for i, x := range data {
-			var total float64
-			probs := make([]float64, k)
-			for j := 0; j < k; j++ {
-				normDist := distuv.Normal{
-					Mu:    gmm.Means[j],
-					Sigma: math.Sqrt(gmm.Variances[j]),
-				}
-				probs[j] = gmm.Weights[j] * normDist.Prob(x)
-				total += probs[j]
-			}
-			for j := 0; j < k; j++ {
-				if total > 0 {
-					responsibilities[i][j] = probs[j] / total
-				} else {
-					responsibilities[i][j] = 1.0 / float64(k)
-				}
-			}
-		}
-
-		// Mステップ: パラメータを更新
+// eStep Eステップ: 各データポイントの負担率を計算する
+func (gmm *GaussianMixture) eStep(data []float64, responsibilities [][]float64) {
+	k := gmm.NComponents
+	for i, x := range data {
+		probs := make([]float64, k)
+		var total float64
 		for j := 0; j < k; j++ {
-			var nk, meanSum, varSum float64
-			for i := 0; i < n; i++ {
-				r := responsibilities[i][j]
-				nk += r
-				meanSum += r * data[i]
+			normDist := distuv.Normal{
+				Mu:    gmm.Means[j],
+				Sigma: math.Sqrt(gmm.Variances[j]),
 			}
-
-			if nk > 1e-10 {
-				gmm.Means[j] = meanSum / nk
-				for i := 0; i < n; i++ {
-					r := responsibilities[i][j]
-					diff := data[i] - gmm.Means[j]
-					varSum += r * diff * diff
-				}
-				gmm.Variances[j] = math.Max(varSum/nk, 1e-6)
-				gmm.Weights[j] = nk / float64(n)
+			probs[j] = gmm.Weights[j] * normDist.Prob(x)
+			total += probs[j]
+		}
+		for j := 0; j < k; j++ {
+			if total > 0 {
+				responsibilities[i][j] = probs[j] / total
+			} else {
+				responsibilities[i][j] = 1.0 / float64(k)
 			}
 		}
-
-		// 対数尤度を計算し、収束をチェック
-		logLikelihood := gmm.logLikelihood(data)
-		if math.Abs(logLikelihood-prevLogLikelihood) < gmm.Tolerance {
-			break
-		}
-		prevLogLikelihood = logLikelihood
 	}
+}
+
+// mStep Mステップ: パラメータを更新する
+func (gmm *GaussianMixture) mStep(data []float64, responsibilities [][]float64) {
+	n := len(data)
+	for j := 0; j < gmm.NComponents; j++ {
+		gmm.updateComponent(j, data, responsibilities, n)
+	}
+}
+
+// updateComponent 1コンポーネント分のパラメータを更新する
+func (gmm *GaussianMixture) updateComponent(j int, data []float64, responsibilities [][]float64, n int) {
+	var nk, meanSum float64
+	for i := 0; i < n; i++ {
+		r := responsibilities[i][j]
+		nk += r
+		meanSum += r * data[i]
+	}
+	if nk <= 1e-10 {
+		return
+	}
+	gmm.Means[j] = meanSum / nk
+	var varSum float64
+	for i := 0; i < n; i++ {
+		r := responsibilities[i][j]
+		diff := data[i] - gmm.Means[j]
+		varSum += r * diff * diff
+	}
+	gmm.Variances[j] = math.Max(varSum/nk, 1e-6)
+	gmm.Weights[j] = nk / float64(n)
 }
 
 // initializeKMeansPlusPlus K-means++を使用して初期中心を選択する
@@ -124,41 +139,46 @@ func (gmm *GaussianMixture) initializeKMeansPlusPlus(data []float64) {
 		return
 	}
 
-	// 最初の中心をランダムに選択
 	gmm.Means[0] = data[rand.Intn(n)]
 
-	// 残りの中心を距離の二乗に比例した確率で選択
 	for i := 1; i < k; i++ {
-		distances := make([]float64, n)
-		var totalDist float64
+		distances, totalDist := calcMinDistances(data, gmm.Means[:i])
+		gmm.Means[i] = selectByDistance(data, distances, totalDist)
+	}
+}
 
-		for j, x := range data {
-			minDist := math.Inf(1)
-			for l := 0; l < i; l++ {
-				dist := (x - gmm.Means[l]) * (x - gmm.Means[l])
-				if dist < minDist {
-					minDist = dist
-				}
+// calcMinDistances 各データポイントから最も近い中心までの距離の二乗を計算する
+func calcMinDistances(data []float64, centers []float64) ([]float64, float64) {
+	distances := make([]float64, len(data))
+	var totalDist float64
+	for j, x := range data {
+		minDist := math.Inf(1)
+		for _, c := range centers {
+			dist := (x - c) * (x - c)
+			if dist < minDist {
+				minDist = dist
 			}
-			distances[j] = minDist
-			totalDist += minDist
 		}
+		distances[j] = minDist
+		totalDist += minDist
+	}
+	return distances, totalDist
+}
 
-		// 距離に比例した確率で選択
-		if totalDist > 0 {
-			r := rand.Float64() * totalDist
-			var cumSum float64
-			for j, d := range distances {
-				cumSum += d
-				if cumSum >= r {
-					gmm.Means[i] = data[j]
-					break
-				}
-			}
-		} else {
-			gmm.Means[i] = data[rand.Intn(n)]
+// selectByDistance 距離の二乗に比例した確率でデータポイントを選択する
+func selectByDistance(data []float64, distances []float64, totalDist float64) float64 {
+	if totalDist <= 0 {
+		return data[rand.Intn(len(data))]
+	}
+	r := rand.Float64() * totalDist
+	var cumSum float64
+	for j, d := range distances {
+		cumSum += d
+		if cumSum >= r {
+			return data[j]
 		}
 	}
+	return data[len(data)-1]
 }
 
 // logLikelihood 対数尤度を計算する

--- a/src/service/activity.go
+++ b/src/service/activity.go
@@ -94,33 +94,22 @@ func getActivityTimeRange(eventID uint, dayOfWeek time.Weekday) (ActivityTimeRan
 		}
 	}
 
-	// 開始時刻の予測
-	var startTime string
-	if len(startTimes) > 0 {
-		startMinutes, err := prediction.GetMostLikelyTime(startTimes, weeks)
-		if err != nil {
-			startTime = "00:00"
-		} else {
-			startTime = lib.MinutesToTime(startMinutes)
-		}
-	} else {
-		startTime = "00:00"
-	}
-
-	// 終了時刻の予測
-	var endTime string
-	if len(endTimes) > 0 {
-		endMinutes, err := prediction.GetMostLikelyTime(endTimes, weeks)
-		if err != nil {
-			endTime = "23:59"
-		} else {
-			endTime = lib.MinutesToTime(endMinutes)
-		}
-	} else {
-		endTime = "23:59"
-	}
+	startTime := predictTime(startTimes, weeks, "00:00")
+	endTime := predictTime(endTimes, weeks, "23:59")
 
 	return ActivityTimeRange{Start: startTime, End: endTime}, nil
+}
+
+// predictTime は時刻リストから最尤時刻を予測する。データ不足やエラー時はデフォルト値を返す
+func predictTime(times []string, weeks int, defaultTime string) string {
+	if len(times) == 0 {
+		return defaultTime
+	}
+	minutes, err := prediction.GetMostLikelyTime(times, weeks)
+	if err != nil {
+		return defaultTime
+	}
+	return lib.MinutesToTime(minutes)
 }
 
 // getUserActivityEventIDs はユーザーが登録している活動のイベントIDセットを取得する
@@ -169,88 +158,84 @@ func filterByCommonActivities(candidates []model.User, receiverActivityEventIDs 
 	return filtered
 }
 
+// extractStartDatetimes は "start" ステータスのログからJST日時文字列を抽出する
+func extractStartDatetimes(logs []model.Log, loc *time.Location) []string {
+	var datetimeStrings []string
+	for _, log := range logs {
+		if log.Status.Name == "start" {
+			datetimeStrings = append(datetimeStrings, log.CreatedAt.In(loc).Format("2006-01-02 15:04"))
+		}
+	}
+	return datetimeStrings
+}
+
+// calcHourlyProbabilities は各時間帯（JST 0〜23時）の確率を計算する
+// H時 = CDF(H:30) - CDF((H-1):30) で (H-1):30〜H:30 の確率密度合計を求める
+func calcHourlyProbabilities(datetimeStrings []string, weeks int) []float64 {
+	probabilities := make([]float64, 24)
+	for hour := 0; hour < 24; hour++ {
+		probabilities[hour] = calcHourProbability(datetimeStrings, hour, weeks)
+	}
+	return probabilities
+}
+
+// calcHourProbability は指定時間帯の確率を計算する
+func calcHourProbability(datetimeStrings []string, hour int, weeks int) float64 {
+	endTimeJST := fmt.Sprintf("%02d:30", hour)
+	startTimeJST := fmt.Sprintf("%02d:30", (hour-1+24)%24)
+
+	cdfEnd, err := prediction.GetProbabilityByUniqueDate(datetimeStrings, endTimeJST, weeks)
+	if err != nil {
+		return 0.0
+	}
+	cdfStart, err := prediction.GetProbabilityByUniqueDate(datetimeStrings, startTimeJST, weeks)
+	if err != nil {
+		return 0.0
+	}
+
+	prob := cdfEnd - cdfStart
+	if prob < 0 {
+		return 0.0
+	}
+	if prob > 1.0 {
+		return 1.0
+	}
+	return prob
+}
+
+// calcEventProbability はイベント1件分の活動確率を計算する
+func calcEventProbability(ev model.Event, dayOfWeek time.Weekday) ActivityProbability {
+	logs, err := model.ReadLogsByEventIDAndDayOfWeek(ev.ID, dayOfWeek)
+	if err != nil || len(logs) == 0 {
+		return ActivityProbability{ActivityName: ev.Name, Probabilities: make([]float64, 24)}
+	}
+
+	weeks := calculateWeeks(logs)
+	datetimeStrings := extractStartDatetimes(logs, lib.JST)
+	if len(datetimeStrings) == 0 {
+		return ActivityProbability{ActivityName: ev.Name, Probabilities: make([]float64, 24)}
+	}
+
+	return ActivityProbability{
+		ActivityName:  ev.Name,
+		Probabilities: calcHourlyProbabilities(datetimeStrings, weeks),
+	}
+}
+
 // GetAllActivityProbabilities は全活動の1時間ごとの発生確率を取得する
 // 各時間帯（JST H時）について、(H-1):30〜H:30 の範囲の確率密度合計を計算する
 // 例: 12時の場合、CDF(12:30) - CDF(11:30) で 11:30〜12:30 の確率を求める
 func GetAllActivityProbabilities(dayOfWeek time.Weekday) ([]ActivityProbability, error) {
-	// 全イベントを取得
 	event := model.Event{}
 	events, err := event.ReadAll()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read events: %w", err)
 	}
 
-	jst := lib.JST
 	var results []ActivityProbability
-
 	for _, ev := range events {
-		probabilities := make([]float64, 24)
-
-		// 該当曜日のログを取得
-		logs, err := model.ReadLogsByEventIDAndDayOfWeek(ev.ID, dayOfWeek)
-		if err != nil || len(logs) == 0 {
-			// データなしの場合は全て0.0
-			results = append(results, ActivityProbability{
-				ActivityName:  ev.Name,
-				Probabilities: probabilities,
-			})
-			continue
-		}
-
-		weeks := calculateWeeks(logs)
-
-		// "start" ステータスのログのみ抽出（日付付き）
-		var datetimeStrings []string
-		for _, log := range logs {
-			if log.Status.Name == "start" {
-				datetimeStr := log.CreatedAt.In(jst).Format("2006-01-02 15:04")
-				datetimeStrings = append(datetimeStrings, datetimeStr)
-			}
-		}
-
-		if len(datetimeStrings) == 0 {
-			results = append(results, ActivityProbability{
-				ActivityName:  ev.Name,
-				Probabilities: probabilities,
-			})
-			continue
-		}
-
-		// 各時間帯（JST 0〜23時）の確率を計算
-		// H時 = CDF(H:30) - CDF((H-1):30) で (H-1):30〜H:30 の確率密度合計を求める
-		// datetimeStringsはJSTなので、targetTimeもJSTで指定する
-		for hour := 0; hour < 24; hour++ {
-			endTimeJST := fmt.Sprintf("%02d:30", hour)
-			startTimeJST := fmt.Sprintf("%02d:30", (hour-1+24)%24)
-
-			cdfEnd, err := prediction.GetProbabilityByUniqueDate(datetimeStrings, endTimeJST, weeks)
-			if err != nil {
-				probabilities[hour] = 0.0
-				continue
-			}
-
-			cdfStart, err := prediction.GetProbabilityByUniqueDate(datetimeStrings, startTimeJST, weeks)
-			if err != nil {
-				probabilities[hour] = 0.0
-				continue
-			}
-
-			prob := cdfEnd - cdfStart
-			if prob < 0 {
-				prob = 0.0
-			}
-			if prob > 1.0 {
-				prob = 1.0
-			}
-			probabilities[hour] = prob
-		}
-
-		results = append(results, ActivityProbability{
-			ActivityName:  ev.Name,
-			Probabilities: probabilities,
-		})
+		results = append(results, calcEventProbability(ev, dayOfWeek))
 	}
-
 	return results, nil
 }
 

--- a/src/service/notification.go
+++ b/src/service/notification.go
@@ -20,10 +20,8 @@ type EventActivity struct {
 
 // NotifyByEvent はイベントベースの通知を生成する
 func NotifyByEvent(targetWeekday time.Weekday) ([]model.User, map[int]map[int][]string) {
-	// UserID → EventID → messages の構造
 	userMessages := make(map[int]map[int][]string)
 
-	// Step 1: 全イベントを Corresponds.User を含めて取得（N+1 クエリ問題を回避）
 	var e model.Event
 	events, err := e.ReadAllWithUsers()
 	if err != nil {
@@ -32,172 +30,165 @@ func NotifyByEvent(targetWeekday time.Weekday) ([]model.User, map[int]map[int][]
 		return users, userMessages
 	}
 
-	// 各ユーザーに対して、参加する全イベントの活動情報を収集
+	userEventActivities := collectUserEventActivities(events, targetWeekday)
+
+	for userID, activities := range userEventActivities {
+		msg := buildUserNotificationMessage(userID, activities)
+		if msg == "" {
+			continue
+		}
+		if userMessages[int(userID)] == nil {
+			userMessages[int(userID)] = make(map[int][]string)
+		}
+		eventID := int(activities[0].EventID)
+		userMessages[int(userID)][eventID] = append(userMessages[int(userID)][eventID], msg)
+	}
+
+	var u model.User
+	users, _ := u.ReadAll()
+	return users, userMessages
+}
+
+// collectUserEventActivities は各イベントを処理し、ユーザーごとの活動情報を収集する
+func collectUserEventActivities(events []model.Event, targetWeekday time.Weekday) map[uint][]EventActivity {
 	userEventActivities := make(map[uint][]EventActivity)
 
-	// Step 2: 各イベントに対して処理
 	for _, event := range events {
-		// Step 2a: 活動確率を取得（閾値チェック）
-		probability, err := GetActivityProbability(event.ID, targetWeekday, "08:59")
-		if err != nil || probability < 0.30 {
-			continue // 確率が閾値未満の場合スキップ
-		}
-
-		// Step 2b: 活動予測時刻範囲を取得
-		activityRange, err := getActivityTimeRange(event.ID, targetWeekday)
-		if err != nil {
+		activity, eventUsers, ok := processEvent(event, targetWeekday)
+		if !ok {
 			continue
 		}
-
-		// Step 2c: イベント参加ユーザーを取得（Preload 済みデータを使用）
-		var eventUsers []model.User
-		for _, c := range event.Corresponds {
-			eventUsers = append(eventUsers, c.User)
-		}
-
-		if len(eventUsers) == 0 {
-			continue
-		}
-
-		// Step 2d: ユーザーの来訪確率・時刻を取得
-		probs := GetStayWatchProbability(eventUsers, targetWeekday)
-		filtered := filterByThreshold(probs, 0.3)
-
-		if len(filtered) == 0 {
-			continue
-		}
-
-		visitTimes := fetchPredictionTime(filtered, targetWeekday, "visit")
-		departureTimes := fetchPredictionTime(filtered, targetWeekday, "departure")
-		predictions := mergePredictions(visitTimes, departureTimes)
-
-		// Step 2e: 規定人数在室時間を計算
-		occupancyRanges := findOverlappingRanges(predictions, eventUsers, event.MinNumber)
-
-		if len(occupancyRanges) == 0 {
-			continue
-		}
-
-		// Step 2f: 活動推奨時間を計算
-		recommendedRanges := calculateRecommendedTimeRanges(activityRange, occupancyRanges)
-
-		if len(recommendedRanges) == 0 {
-			continue
-		}
-
-		// Step 2g: 各ユーザーの活動情報を収集
-		activity := EventActivity{
-			EventID:           event.ID,
-			EventName:         event.Name,
-			RecommendedRanges: recommendedRanges,
-			FilteredUsers:     filtered,
-			Predictions:       predictions,
-		}
-
 		for _, eventUser := range eventUsers {
 			userEventActivities[eventUser.ID] = append(userEventActivities[eventUser.ID], activity)
 		}
 	}
 
-	// Step 3: ユーザーごとにメッセージを生成
-	for userID, activities := range userEventActivities {
-		if len(activities) == 0 {
-			continue
-		}
+	return userEventActivities
+}
 
-		// ユーザーの活動イベントIDを取得
-		receiverActivityEventIDs := getUserActivityEventIDs(userID)
-
-		// 全アクティビティの時間帯を先にリストアップ
-		var activityHeaders []string
-		allFilteredUsers := make(map[int64]model.User) // StayWatchID → User
-		var allPredictions []Prediction
-
-		for _, activity := range activities {
-			for _, r := range activity.RecommendedRanges {
-				header := fmt.Sprintf("%s〜%s  `%s`", r.Start, r.End, activity.EventName)
-				activityHeaders = append(activityHeaders, header)
-			}
-
-			// 全ユーザーと予測情報を収集（重複排除）
-			for _, user := range activity.FilteredUsers {
-				allFilteredUsers[user.StayWatchID] = user
-			}
-			allPredictions = append(allPredictions, activity.Predictions...)
-		}
-
-		// 収集したユーザーをスライスに変換
-		var uniqueFilteredUsers []model.User
-		for _, user := range allFilteredUsers {
-			uniqueFilteredUsers = append(uniqueFilteredUsers, user)
-		}
-
-		// 受信者と共通の活動を持つユーザーだけをフィルタリング
-		commonActivityUsers := filterByCommonActivities(uniqueFilteredUsers, receiverActivityEventIDs, userID)
-
-		if len(commonActivityUsers) == 0 {
-			continue
-		}
-
-		// メッセージを組み立て
-		var msgBuilder strings.Builder
-
-		// 1. 全アクティビティの時間帯を記載
-		for _, header := range activityHeaders {
-			msgBuilder.WriteString(header + "\n")
-		}
-
-		// 2. 「来そうな人」セクションを追加
-		msgBuilder.WriteString("\n来そうな人↓\n")
-
-		// ユーザーを名前順にソート
-		sort.Slice(commonActivityUsers, func(i, j int) bool {
-			return commonActivityUsers[i].Name < commonActivityUsers[j].Name
-		})
-
-		// ループ前に全ユーザーのタグを一括取得（DB クエリの重複を防ぐ）
-		activityTagsCache := make(map[uint][]string)
-		for _, user := range commonActivityUsers {
-			tags, err := getUserActivityTags(user.ID)
-			if err != nil {
-				tags = []string{}
-			}
-			activityTagsCache[user.ID] = tags
-		}
-
-		for _, user := range commonActivityUsers {
-			// 予測時刻を取得（最初に見つかったものを使用）
-			visit, departure, found := findPredictionForUser(user.StayWatchID, allPredictions)
-			if !found {
-				continue
-			}
-
-			// キャッシュからユーザーの活動タグを取得
-			activityTags := activityTagsCache[user.ID]
-
-			// ユーザー行を生成
-			userLine := formatUserLine(user.Name, activityTags, visit, departure)
-			msgBuilder.WriteString(userLine + "\n")
-		}
-
-		msg := msgBuilder.String()
-
-		// UserID → EventID → messages の構造に追加
-		// 全イベントに対して同じメッセージを送る
-		if userMessages[int(userID)] == nil {
-			userMessages[int(userID)] = make(map[int][]string)
-		}
-		// 最初のアクティビティのEventIDをキーとして使用
-		userMessages[int(userID)][int(activities[0].EventID)] = append(
-			userMessages[int(userID)][int(activities[0].EventID)],
-			msg,
-		)
+// processEvent は1イベントの活動確率・推奨時間を計算し、EventActivityを返す
+func processEvent(event model.Event, targetWeekday time.Weekday) (EventActivity, []model.User, bool) {
+	probability, err := GetActivityProbability(event.ID, targetWeekday, "08:59")
+	if err != nil || probability < 0.30 {
+		return EventActivity{}, nil, false
 	}
 
-	// 全ユーザーを返却（既存の Slack DM 送信との互換性のため）
-	var u model.User
-	users, _ := u.ReadAll()
-	return users, userMessages
+	activityRange, err := getActivityTimeRange(event.ID, targetWeekday)
+	if err != nil {
+		return EventActivity{}, nil, false
+	}
+
+	var eventUsers []model.User
+	for _, c := range event.Corresponds {
+		eventUsers = append(eventUsers, c.User)
+	}
+	if len(eventUsers) == 0 {
+		return EventActivity{}, nil, false
+	}
+
+	probs := GetStayWatchProbability(eventUsers, targetWeekday)
+	filtered := filterByThreshold(probs, 0.3)
+	if len(filtered) == 0 {
+		return EventActivity{}, nil, false
+	}
+
+	visitTimes := fetchPredictionTime(filtered, targetWeekday, "visit")
+	departureTimes := fetchPredictionTime(filtered, targetWeekday, "departure")
+	predictions := mergePredictions(visitTimes, departureTimes)
+
+	occupancyRanges := findOverlappingRanges(predictions, eventUsers, event.MinNumber)
+	if len(occupancyRanges) == 0 {
+		return EventActivity{}, nil, false
+	}
+
+	recommendedRanges := calculateRecommendedTimeRanges(activityRange, occupancyRanges)
+	if len(recommendedRanges) == 0 {
+		return EventActivity{}, nil, false
+	}
+
+	activity := EventActivity{
+		EventID:           event.ID,
+		EventName:         event.Name,
+		RecommendedRanges: recommendedRanges,
+		FilteredUsers:     filtered,
+		Predictions:       predictions,
+	}
+	return activity, eventUsers, true
+}
+
+// aggregateActivities は複数のEventActivityからヘッダー・ユーザー・予測情報を集約する
+func aggregateActivities(activities []EventActivity) ([]string, []model.User, []Prediction) {
+	var headers []string
+	allUsers := make(map[int64]model.User)
+	var allPredictions []Prediction
+
+	for _, activity := range activities {
+		for _, r := range activity.RecommendedRanges {
+			headers = append(headers, fmt.Sprintf("%s〜%s  `%s`", r.Start, r.End, activity.EventName))
+		}
+		for _, user := range activity.FilteredUsers {
+			allUsers[user.StayWatchID] = user
+		}
+		allPredictions = append(allPredictions, activity.Predictions...)
+	}
+
+	var uniqueUsers []model.User
+	for _, user := range allUsers {
+		uniqueUsers = append(uniqueUsers, user)
+	}
+
+	return headers, uniqueUsers, allPredictions
+}
+
+// buildUserNotificationMessage はユーザー1人分の通知メッセージを生成する
+func buildUserNotificationMessage(userID uint, activities []EventActivity) string {
+	if len(activities) == 0 {
+		return ""
+	}
+
+	receiverActivityEventIDs := getUserActivityEventIDs(userID)
+	headers, uniqueUsers, allPredictions := aggregateActivities(activities)
+
+	commonActivityUsers := filterByCommonActivities(uniqueUsers, receiverActivityEventIDs, userID)
+	if len(commonActivityUsers) == 0 {
+		return ""
+	}
+
+	sort.Slice(commonActivityUsers, func(i, j int) bool {
+		return commonActivityUsers[i].Name < commonActivityUsers[j].Name
+	})
+
+	var msgBuilder strings.Builder
+	for _, header := range headers {
+		msgBuilder.WriteString(header + "\n")
+	}
+	msgBuilder.WriteString("\n来そうな人↓\n")
+
+	activityTagsCache := buildActivityTagsCache(commonActivityUsers)
+
+	for _, user := range commonActivityUsers {
+		visit, departure, found := findPredictionForUser(user.StayWatchID, allPredictions)
+		if !found {
+			continue
+		}
+		userLine := formatUserLine(user.Name, activityTagsCache[user.ID], visit, departure)
+		msgBuilder.WriteString(userLine + "\n")
+	}
+
+	return msgBuilder.String()
+}
+
+// buildActivityTagsCache はユーザーリストの活動タグを一括取得してキャッシュを返す
+func buildActivityTagsCache(users []model.User) map[uint][]string {
+	cache := make(map[uint][]string)
+	for _, user := range users {
+		tags, err := getUserActivityTags(user.ID)
+		if err != nil {
+			tags = []string{}
+		}
+		cache[user.ID] = tags
+	}
+	return cache
 }
 
 // findPredictionForUser はユーザーの予測滞在時間を検索する


### PR DESCRIPTION
## Summary
- 複数ファイルの関数を分割し、Cognitive Complexityを許容値(15)以下に削減
- `slack_dm.go`, `notification.go`, `slack_interaction.go`, `clustering.go`, `activity.go` の各関数からヘルパー関数を抽出
- `"internal server error"` リテラルの重複を定数 `msgInternalServerError` に統一
- `gin-contrib/cors` を indirect から直接依存に移動

## Test plan
- [ ] `go build ./...` でビルドが通ることを確認済み
- [ ] DM送信・イベント登録・モーダル操作などの既存機能が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)