### PR TITLE
fix: 活動確率APIのNaN JSONシリアライズエラーを修正

### DIFF
--- a/src/prediction/probability.go
+++ b/src/prediction/probability.go
@@ -2,6 +2,7 @@ package prediction
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/kajiLabTeam/stay-watch-slackbot/lib"
@@ -82,7 +83,11 @@ func calcClusterProbability(c ClusteringResult, timeMinutes int, weeks int) floa
 		Sigma: scale,
 	}
 	cdf := normDist.CDF(float64(timeMinutes))
-	return cdf * (float64(len(c.Data)) / float64(weeks))
+	result := cdf * (float64(len(c.Data)) / float64(weeks))
+	if math.IsNaN(result) || math.IsInf(result, 0) {
+		return 0
+	}
+	return result
 }
 
 // GetProbabilityByUniqueDate 来訪確率を計算する（日付重複を排除）

--- a/src/service/activity.go
+++ b/src/service/activity.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/kajiLabTeam/stay-watch-slackbot/lib"
@@ -194,7 +195,7 @@ func calcHourProbability(datetimeStrings []string, hour int, weeks int) float64 
 	}
 
 	prob := cdfEnd - cdfStart
-	if prob < 0 {
+	if math.IsNaN(prob) || math.IsInf(prob, 0) || prob < 0 {
 		return 0.0
 	}
 	if prob > 1.0 {


### PR DESCRIPTION
## Summary
- `/api/activities/probabilities` で `json: unsupported value: NaN` エラーが発生する問題を修正
- 確率計算（CDF）の結果がNaN/Infになるケースに対して0を返すガードを追加
- `prediction/probability.go` と `service/activity.go` の2箇所に防御処理を追加

## Test plan
- [ ] `/api/activities/probabilities` を呼び出してJSONレスポンスが正常に返ることを確認
- [ ] データが少ないイベントでもエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)