### PR TITLE
refactor: logsテーブルのcreated_atをevent_timeに分離し、時刻をJSTに統一

### DIFF
--- a/src/controller/api.go
+++ b/src/controller/api.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/kajiLabTeam/stay-watch-slackbot/lib"
 	"github.com/kajiLabTeam/stay-watch-slackbot/service"
 )
 
@@ -33,7 +34,7 @@ type RegisterStatusesRequest struct {
 type LogEntry struct {
 	EventID   uint   `json:"event_id" binding:"required"`
 	StatusID  uint   `json:"status_id" binding:"required"`
-	CreatedAt string `json:"created_at" binding:"required"` // RFC3339形式 JST or UTC (例: "2006-01-02T15:04:05+09:00" or "2006-01-02T15:04:05Z")
+	CreatedAt string `json:"created_at" binding:"required"` // RFC3339形式 JST (例: "2006-01-02T15:04:05+09:00")
 }
 
 // RegisterLogsRequest はログ一括登録のリクエストボディ
@@ -223,19 +224,16 @@ func GetEventProbability(c *gin.Context) {
 	weekday := time.Weekday((weekdayInt + 1) % 7)
 
 	// クエリパラメータから時刻を取得（オプション、デフォルトは現在時刻JST）
-	jst := time.FixedZone("JST", 9*60*60)
-	inputTimeJST := c.DefaultQuery("time", time.Now().In(jst).Format("15:04"))
+	targetTimeJST := c.DefaultQuery("time", lib.NowJST().Format("15:04"))
 
-	// JST入力をUTCに変換
-	parsedJST, err := time.ParseInLocation("15:04", inputTimeJST, jst)
-	if err != nil {
+	// JSTの時刻をそのまま使用（DB・内部処理すべてJST統一）
+	if _, err := time.ParseInLocation("15:04", targetTimeJST, lib.JST); err != nil {
 		respondError(c, http.StatusBadRequest, "invalid time format (expected HH:MM)")
 		return
 	}
-	targetTimeUTC := parsedJST.UTC().Format("15:04")
 
 	// 確率を取得
-	probability, err := service.GetActivityProbability(uint(eventID), weekday, targetTimeUTC)
+	probability, err := service.GetActivityProbability(uint(eventID), weekday, targetTimeJST)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, err.Error())
 		return
@@ -244,7 +242,7 @@ func GetEventProbability(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"event_id":    eventID,
 		"weekday":     weekdayInt,
-		"time":        inputTimeJST,
+		"time":        targetTimeJST,
 		"probability": probability,
 	})
 }
@@ -259,13 +257,12 @@ func GetEventProbability(c *gin.Context) {
 // @Failure 500 {object} map[string]interface{}
 // @Router /api/activities/probabilities [get]
 func GetAllActivityProbabilities(c *gin.Context) {
-	jst := time.FixedZone("JST", 9*60*60)
 	var weekday time.Weekday
 
 	weekdayStr := c.Query("weekday")
 	if weekdayStr == "" {
 		// デフォルト: 今日の曜日（JST）
-		weekday = time.Now().In(jst).Weekday()
+		weekday = lib.NowJST().Weekday()
 	} else {
 		weekdayInt, err := strconv.Atoi(weekdayStr)
 		if err != nil || weekdayInt < 0 || weekdayInt > 6 {

--- a/src/controller/api.go
+++ b/src/controller/api.go
@@ -34,7 +34,7 @@ type RegisterStatusesRequest struct {
 type LogEntry struct {
 	EventID   uint   `json:"event_id" binding:"required"`
 	StatusID  uint   `json:"status_id" binding:"required"`
-	CreatedAt string `json:"created_at" binding:"required"` // RFC3339形式 JST (例: "2006-01-02T15:04:05+09:00")
+	EventTime string `json:"event_time" binding:"required"` // RFC3339形式 JST (例: "2006-01-02T15:04:05+09:00")
 }
 
 // RegisterLogsRequest はログ一括登録のリクエストボディ
@@ -307,7 +307,7 @@ func PostRegisterLogs(c *gin.Context) {
 		inputs[i] = service.LogEntryInput{
 			EventID:   entry.EventID,
 			StatusID:  entry.StatusID,
-			CreatedAt: entry.CreatedAt,
+			EventTime: entry.EventTime,
 		}
 	}
 

--- a/src/controller/slack_dm.go
+++ b/src/controller/slack_dm.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/kajiLabTeam/stay-watch-slackbot/lib"
 	"github.com/kajiLabTeam/stay-watch-slackbot/model"
 	"github.com/kajiLabTeam/stay-watch-slackbot/service"
 	"github.com/slack-go/slack"
@@ -47,8 +48,7 @@ func SendDM(c *gin.Context) {
 
 func parseTargetWeekday(param string) (time.Weekday, error) {
 	if param == "" {
-		jst := time.FixedZone("JST", 9*60*60)
-		tomorrow := time.Now().In(jst).AddDate(0, 0, 1)
+		tomorrow := lib.NowJST().AddDate(0, 0, 1)
 		return tomorrow.Weekday(), nil
 	}
 	weekdayInt, err := strconv.Atoi(param)
@@ -102,8 +102,7 @@ func sendDMToUser(c *gin.Context, logger *log.Logger, user model.User, userMessa
 		return
 	}
 
-	jst := time.FixedZone("JST", 9*60*60)
-	now := time.Now().UTC().In(jst)
+	now := lib.NowJST()
 	logger.Printf("[%s] 送信先: %s (SlackID: %s)\n推奨活動内容:\n%s\n---\n",
 		now.Format("2006-01-02 15:04:05"),
 		user.Name,

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -391,7 +391,7 @@ const docTemplate = `{
             ],
             "properties": {
                 "created_at": {
-                    "description": "RFC3339形式 JST or UTC (例: \"2006-01-02T15:04:05+09:00\" or \"2006-01-02T15:04:05Z\")",
+                    "description": "RFC3339形式 JST (例: \"2006-01-02T15:04:05+09:00\")",
                     "type": "string"
                 },
                 "event_id": {

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -3,7 +3,7 @@ definitions:
   controller.LogEntry:
     properties:
       created_at:
-        description: 'RFC3339形式 JST or UTC (例: "2006-01-02T15:04:05+09:00" or "2006-01-02T15:04:05Z")'
+        description: 'RFC3339形式 JST (例: "2006-01-02T15:04:05+09:00")'
         type: string
       event_id:
         type: integer

--- a/src/lib/sql.go
+++ b/src/lib/sql.go
@@ -25,7 +25,7 @@ func SQLConnect() (database *gorm.DB) {
 	protocol := getEnv("MYSQL_PROTOCOL", "")
 	dbname := getEnv("MYSQL_DBNAME", "")
 
-	dsn := fmt.Sprintf("%s:%s@%s/%s?charset=utf8&parseTime=true&loc=UTC",
+	dsn := fmt.Sprintf("%s:%s@%s/%s?charset=utf8&parseTime=true&loc=Asia%%2FTokyo",
 		user, password, protocol, dbname)
 	dialector := mysql.Open(dsn)
 	// log.Default().Println(dsn)

--- a/src/lib/time_utils.go
+++ b/src/lib/time_utils.go
@@ -8,36 +8,22 @@ import (
 	"time"
 )
 
-// JST は日本標準時（表示用、固定）
+// JST は日本標準時
 var JST = time.FixedZone("JST", 9*60*60)
 
-// StayWatchTimezone はStayWatch APIが使用するタイムゾーン
-// TODO: StayWatchがUTCに移行したら time.UTC に変更する
-var StayWatchTimezone = time.FixedZone("JST", 9*60*60)
-
-// ToJST はUTC時刻をJSTに変換する（Slack表示用）
-func ToJST(t time.Time) time.Time {
-	return t.In(JST)
+// FormatTime は時刻を"HH:MM"形式にフォーマットする
+func FormatTime(t time.Time) string {
+	return t.In(JST).Format("15:04")
 }
 
-// FormatTimeJST はUTC時刻をJSTの"HH:MM"形式に変換する（Slack表示用）
-func FormatTimeJST(t time.Time) string {
-	return ToJST(t).Format("15:04")
+// FormatDateTime は時刻を"2006-01-02 15:04"形式にフォーマットする
+func FormatDateTime(t time.Time) string {
+	return t.In(JST).Format("2006-01-02 15:04")
 }
 
-// ToStayWatchTime はUTC時刻をStayWatchのタイムゾーンに変換する
-func ToStayWatchTime(t time.Time) time.Time {
-	return t.In(StayWatchTimezone)
-}
-
-// FormatForStayWatch はUTC時刻をStayWatch用の"HH:MM"形式に変換する
-func FormatForStayWatch(t time.Time) string {
-	return ToStayWatchTime(t).Format("15:04")
-}
-
-// FormatDateTimeForStayWatch はUTC時刻をStayWatch用の"2006-01-02 15:04"形式に変換する
-func FormatDateTimeForStayWatch(t time.Time) string {
-	return ToStayWatchTime(t).Format("2006-01-02 15:04")
+// NowJST は現在時刻をJSTで返す
+func NowJST() time.Time {
+	return time.Now().In(JST)
 }
 
 // TimeToMinutes "HH:MM"形式の時刻を分に変換する
@@ -67,51 +53,19 @@ func MinutesToTime(minutes int) string {
 	return fmt.Sprintf("%02d:%02d", hours, mins)
 }
 
-// ErrUnsupportedTimezone は対応していないタイムゾーンの場合のエラー
-var ErrUnsupportedTimezone = fmt.Errorf("timezone must be JST (+09:00) or UTC (+00:00/Z)")
-
-// ErrNoTimezone は入力時刻にタイムゾーン情報がない場合のエラー
-var ErrNoTimezone = fmt.Errorf("timezone information is required (use RFC3339 format, e.g., 2006-01-02T15:04:05+09:00)")
-
-// TimezoneType は検出されたタイムゾーンの種類を表す
-type TimezoneType string
-
-const (
-	TimezoneJST TimezoneType = "JST"
-	TimezoneUTC TimezoneType = "UTC"
-)
-
-// ParseResult はパース結果を表す
-type ParseResult struct {
-	Time     time.Time    // UTC変換後の時刻
-	Timezone TimezoneType // 検出されたタイムゾーン
-}
-
-// ParseWithTimezoneDetection はRFC3339形式の時刻文字列をパースし、タイムゾーンを判別してUTCに変換する
-// 入力形式: "2006-01-02T15:04:05+09:00" (JST) または "2006-01-02T15:04:05Z" / "2006-01-02T15:04:05+00:00" (UTC)
-// JSTまたはUTC以外のタイムゾーン、またはタイムゾーン情報がない場合はエラーを返す
-func ParseWithTimezoneDetection(timeStr string) (ParseResult, error) {
-	// RFC3339形式でパース
+// ParseJST はRFC3339形式の時刻文字列をパースしてJSTに変換する
+// 入力形式: "2006-01-02T15:04:05+09:00" (JST)
+// JST以外のタイムゾーンはエラーを返す
+func ParseJST(timeStr string) (time.Time, error) {
 	t, err := time.Parse(time.RFC3339, timeStr)
 	if err != nil {
-		return ParseResult{}, ErrNoTimezone
+		return time.Time{}, fmt.Errorf("RFC3339形式で入力してください (例: 2006-01-02T15:04:05+09:00): %w", err)
 	}
 
-	// タイムゾーンオフセットを確認
 	_, offset := t.Zone()
-
-	switch offset {
-	case 9 * 60 * 60: // JST (+09:00)
-		return ParseResult{
-			Time:     t.UTC(),
-			Timezone: TimezoneJST,
-		}, nil
-	case 0: // UTC (+00:00 or Z)
-		return ParseResult{
-			Time:     t.UTC(),
-			Timezone: TimezoneUTC,
-		}, nil
-	default:
-		return ParseResult{}, ErrUnsupportedTimezone
+	if offset != 9*60*60 {
+		return time.Time{}, fmt.Errorf("タイムゾーンはJST (+09:00) のみ対応しています")
 	}
+
+	return t.In(JST), nil
 }

--- a/src/model/log.go
+++ b/src/model/log.go
@@ -38,7 +38,7 @@ func (l *Log) ReadByEventID() ([]Log, error) {
 // ReadLogsByEventIDAndDateRange retrieves logs by event ID and date range
 func ReadLogsByEventIDAndDateRange(eventID uint, startDate, endDate time.Time) ([]Log, error) {
 	var logs []Log
-	if err := db.Where("event_id = ? AND logs.created_at BETWEEN ? AND ?", eventID, startDate, endDate).
+	if err := db.Where("event_id = ? AND logs.event_time BETWEEN ? AND ?", eventID, startDate, endDate).
 		Preload("Event").
 		Preload("Status").
 		Find(&logs).Error; err != nil {
@@ -55,7 +55,7 @@ func ReadLogsByEventIDAndDayOfWeek(eventID uint, dayOfWeek time.Weekday) ([]Log,
 	mysqlDayOfWeek := (int(dayOfWeek) + 6) % 7
 
 	// 指定した曜日のログを全て取得
-	if err := db.Where("event_id = ? AND WEEKDAY(logs.created_at) = ?", eventID, mysqlDayOfWeek).
+	if err := db.Where("event_id = ? AND WEEKDAY(logs.event_time) = ?", eventID, mysqlDayOfWeek).
 		Preload("Event").
 		Preload("Status").
 		Find(&logs).Error; err != nil {
@@ -73,7 +73,7 @@ func ReadLogsByEventIDAndDayOfWeekWithWeeks(eventID uint, dayOfWeek time.Weekday
 	mysqlDayOfWeek := (int(dayOfWeek) + 6) % 7
 
 	// 指定した曜日、指定した週数のログを全て取得
-	if err := db.Where("event_id = ? AND WEEKDAY(logs.created_at) = ?", eventID, mysqlDayOfWeek).
+	if err := db.Where("event_id = ? AND WEEKDAY(logs.event_time) = ?", eventID, mysqlDayOfWeek).
 		Preload("Event").
 		Preload("Status").
 		Find(&logs).Error; err != nil {

--- a/src/model/struct.go
+++ b/src/model/struct.go
@@ -2,6 +2,8 @@
 package model
 
 import (
+	"time"
+
 	"github.com/kajiLabTeam/stay-watch-slackbot/lib"
 	"gorm.io/gorm"
 )
@@ -58,11 +60,15 @@ type Correspond struct {
 
 // Log は活動ログを表す
 type Log struct {
-	gorm.Model
-	EventID  uint
-	Event    Event `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
-	StatusID uint
-	Status   Status `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	ID        uint           `gorm:"primarykey"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index"`
+	EventTime time.Time
+	EventID   uint
+	Event     Event `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	StatusID  uint
+	Status    Status `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 }
 
 // UserDetail は来訪予測を含む詳細なユーザー情報を表す

--- a/src/service/activity.go
+++ b/src/service/activity.go
@@ -29,12 +29,12 @@ func calculateWeeks(logs []model.Log) int {
 	}
 	oldestLog := logs[0]
 	for _, log := range logs {
-		if log.CreatedAt.Before(oldestLog.CreatedAt) {
+		if log.EventTime.Before(oldestLog.EventTime) {
 			oldestLog = log
 		}
 	}
 	now := lib.NowJST()
-	days := int(now.Sub(oldestLog.CreatedAt).Hours() / 24)
+	days := int(now.Sub(oldestLog.EventTime).Hours() / 24)
 	return (days / 7) + 1
 }
 
@@ -54,7 +54,7 @@ func GetActivityProbability(eventID uint, dayOfWeek time.Weekday, targetTime str
 	var datetimeStrings []string
 	for _, log := range logs {
 		if log.Status.Name == "start" {
-			datetimeStr := log.CreatedAt.Format("2006-01-02 15:04")
+			datetimeStr := log.EventTime.Format("2006-01-02 15:04")
 			datetimeStrings = append(datetimeStrings, datetimeStr)
 		}
 	}
@@ -85,7 +85,7 @@ func getActivityTimeRange(eventID uint, dayOfWeek time.Weekday) (ActivityTimeRan
 	var startTimes []string
 	var endTimes []string
 	for _, log := range logs {
-		timeStr := lib.FormatTime(log.CreatedAt)
+		timeStr := lib.FormatTime(log.EventTime)
 		switch log.Status.Name {
 		case "start":
 			startTimes = append(startTimes, timeStr)
@@ -163,7 +163,7 @@ func extractStartDatetimes(logs []model.Log) []string {
 	var datetimeStrings []string
 	for _, log := range logs {
 		if log.Status.Name == "start" {
-			datetimeStrings = append(datetimeStrings, log.CreatedAt.Format("2006-01-02 15:04"))
+			datetimeStrings = append(datetimeStrings, log.EventTime.Format("2006-01-02 15:04"))
 		}
 	}
 	return datetimeStrings

--- a/src/service/activity.go
+++ b/src/service/activity.go
@@ -33,7 +33,7 @@ func calculateWeeks(logs []model.Log) int {
 			oldestLog = log
 		}
 	}
-	now := time.Now().UTC()
+	now := lib.NowJST()
 	days := int(now.Sub(oldestLog.CreatedAt).Hours() / 24)
 	return (days / 7) + 1
 }
@@ -50,7 +50,7 @@ func GetActivityProbability(eventID uint, dayOfWeek time.Weekday, targetTime str
 	weeks := calculateWeeks(logs)
 
 	// 3. Status が "start" のログをフィルタリング（日付付き）
-	// DBはUTCなのでそのまま使用（targetTimeもUTC）
+	// DBはJSTなのでそのまま使用（targetTimeもJST）
 	var datetimeStrings []string
 	for _, log := range logs {
 		if log.Status.Name == "start" {
@@ -81,12 +81,11 @@ func getActivityTimeRange(eventID uint, dayOfWeek time.Weekday) (ActivityTimeRan
 
 	weeks := calculateWeeks(logs)
 
-	// start と end のログを分離
-	// Slack表示用にJSTに変換
+	// start と end のログを分離（DBはJSTなのでそのまま使用）
 	var startTimes []string
 	var endTimes []string
 	for _, log := range logs {
-		timeStr := lib.FormatTimeJST(log.CreatedAt)
+		timeStr := lib.FormatTime(log.CreatedAt)
 		switch log.Status.Name {
 		case "start":
 			startTimes = append(startTimes, timeStr)
@@ -160,11 +159,11 @@ func filterByCommonActivities(candidates []model.User, receiverActivityEventIDs 
 }
 
 // extractStartDatetimes は "start" ステータスのログからJST日時文字列を抽出する
-func extractStartDatetimes(logs []model.Log, loc *time.Location) []string {
+func extractStartDatetimes(logs []model.Log) []string {
 	var datetimeStrings []string
 	for _, log := range logs {
 		if log.Status.Name == "start" {
-			datetimeStrings = append(datetimeStrings, log.CreatedAt.In(loc).Format("2006-01-02 15:04"))
+			datetimeStrings = append(datetimeStrings, log.CreatedAt.Format("2006-01-02 15:04"))
 		}
 	}
 	return datetimeStrings
@@ -212,7 +211,7 @@ func calcEventProbability(ev model.Event, dayOfWeek time.Weekday) ActivityProbab
 	}
 
 	weeks := calculateWeeks(logs)
-	datetimeStrings := extractStartDatetimes(logs, lib.JST)
+	datetimeStrings := extractStartDatetimes(logs)
 	if len(datetimeStrings) == 0 {
 		return ActivityProbability{ActivityName: ev.Name, Probabilities: make([]float64, 24)}
 	}

--- a/src/service/log.go
+++ b/src/service/log.go
@@ -11,7 +11,7 @@ import (
 type LogEntryInput struct {
 	EventID   uint
 	StatusID  uint
-	CreatedAt string // RFC3339形式 JST (例: "2006-01-02T15:04:05+09:00")
+	EventTime string // RFC3339形式 JST (例: "2006-01-02T15:04:05+09:00")
 }
 
 // RegisterLog は単一のログを登録する（JST検証付き）
@@ -31,17 +31,17 @@ func RegisterLog(input LogEntryInput) (model.Log, error) {
 	}
 
 	// 時刻をパース（JSTのみ許可）
-	createdAtJST, err := lib.ParseJST(input.CreatedAt)
+	eventTimeJST, err := lib.ParseJST(input.EventTime)
 	if err != nil {
-		return model.Log{}, fmt.Errorf("invalid created_at: %v", err)
+		return model.Log{}, fmt.Errorf("invalid event_time: %v", err)
 	}
 
 	// ログを作成
 	log := model.Log{
-		EventID:  input.EventID,
-		StatusID: input.StatusID,
+		EventID:   input.EventID,
+		StatusID:  input.StatusID,
+		EventTime: eventTimeJST,
 	}
-	log.CreatedAt = createdAtJST
 
 	if err := log.Create(); err != nil {
 		return model.Log{}, err

--- a/src/service/log.go
+++ b/src/service/log.go
@@ -11,10 +11,10 @@ import (
 type LogEntryInput struct {
 	EventID   uint
 	StatusID  uint
-	CreatedAt string // RFC3339形式 (JSTまたはUTC、例: "2006-01-02T15:04:05+09:00" or "2006-01-02T15:04:05Z")
+	CreatedAt string // RFC3339形式 JST (例: "2006-01-02T15:04:05+09:00")
 }
 
-// RegisterLog は単一のログを登録する（JST→UTC変換、外部キー検証）
+// RegisterLog は単一のログを登録する（JST検証付き）
 func RegisterLog(input LogEntryInput) (model.Log, error) {
 	// Event存在確認
 	event := model.Event{}
@@ -30,20 +30,18 @@ func RegisterLog(input LogEntryInput) (model.Log, error) {
 		return model.Log{}, fmt.Errorf("status_id %d not found", input.StatusID)
 	}
 
-	// 時刻をパースしてUTCに変換（タイムゾーン検証付き: JST or UTC のみ許可）
-	parseResult, err := lib.ParseWithTimezoneDetection(input.CreatedAt)
+	// 時刻をパース（JSTのみ許可）
+	createdAtJST, err := lib.ParseJST(input.CreatedAt)
 	if err != nil {
 		return model.Log{}, fmt.Errorf("invalid created_at: %v", err)
 	}
-	createdAtUTC := parseResult.Time
 
 	// ログを作成
 	log := model.Log{
 		EventID:  input.EventID,
 		StatusID: input.StatusID,
 	}
-	// CreatedAtを手動で設定するためにgorm.Modelを直接操作
-	log.CreatedAt = createdAtUTC
+	log.CreatedAt = createdAtJST
 
 	if err := log.Create(); err != nil {
 		return model.Log{}, err

--- a/src/service/notification.go
+++ b/src/service/notification.go
@@ -68,7 +68,7 @@ func collectUserEventActivities(events []model.Event, targetWeekday time.Weekday
 
 // processEvent は1イベントの活動確率・推奨時間を計算し、EventActivityを返す
 func processEvent(event model.Event, targetWeekday time.Weekday) (EventActivity, []model.User, bool) {
-	probability, err := GetActivityProbability(event.ID, targetWeekday, "08:59")
+	probability, err := GetActivityProbability(event.ID, targetWeekday, "17:59")
 	if err != nil || probability < 0.30 {
 		return EventActivity{}, nil, false
 	}

--- a/src/service/slack_event.go
+++ b/src/service/slack_event.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/kajiLabTeam/stay-watch-slackbot/lib"
 	"github.com/slack-go/slack"
 )
 
@@ -26,7 +27,7 @@ func GetProbability(userID int) (Probability, string, error) {
 	}
 
 	var probability Probability
-	now := time.Now().UTC()
+	now := time.Now().In(lib.JST)
 	timeStr := now.Format("15:04")
 	w := now.Weekday()
 	// 月曜を0とする変換


### PR DESCRIPTION
## Summary
- システム全体の時刻をJSTに統一し、UTC変換ロジックを削除
- logsテーブルの`created_at`をイベント発生時刻専用の`event_time`カラムに分離
- `created_at`/`updated_at`/`deleted_at`はGORMの自動管理に変更

## Test plan
- [ ] マイグレーション（ALTER TABLE）が正常に適用されることを確認
- [ ] ログ登録APIで`event_time`フィールドが正しく保存されることを確認
- [ ] 活動確率計算が`event_time`ベースで正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)