### PR TITLE
fix: 同じ日に複数回発生する活動の確率計算を修正

### DIFF
--- a/src/prediction/probability.go
+++ b/src/prediction/probability.go
@@ -122,6 +122,25 @@ func GetProbabilityByUniqueDate(data []string, time string, weeks int) (float64,
 	return GetProbability(uniqueTimes, time, weeks)
 }
 
+// GetProbabilityFromDatetimes 来訪確率を計算する（日付重複排除なし）
+// 同じ日に複数の活動がある場合もすべての時刻を使用する
+// data: "2006-01-02 15:04"形式の日付時刻文字列スライス
+// time: "HH:MM"形式の時刻文字列
+// weeks: 週数
+func GetProbabilityFromDatetimes(data []string, time string, weeks int) (float64, error) {
+	// datetime文字列から時刻部分のみを抽出（重複排除しない）
+	times := make([]string, 0, len(data))
+	for _, d := range data {
+		parts := strings.SplitN(d, " ", 2)
+		if len(parts) != 2 {
+			return 0, fmt.Errorf("invalid datetime format: %s", d)
+		}
+		times = append(times, parts[1])
+	}
+
+	return GetProbability(times, time, weeks)
+}
+
 // GetMostLikelyTime 活動の最も可能性の高い時間を見つける
 // 各クラスタをガウス分布とした場合の頂点（中心）の時刻に重みを付与し、その合計を返す
 func GetMostLikelyTime(data []string, weeks int) (int, error) {

--- a/src/service/activity.go
+++ b/src/service/activity.go
@@ -184,11 +184,11 @@ func calcHourProbability(datetimeStrings []string, hour int, weeks int) float64 
 	endTimeJST := fmt.Sprintf("%02d:30", hour)
 	startTimeJST := fmt.Sprintf("%02d:30", (hour-1+24)%24)
 
-	cdfEnd, err := prediction.GetProbabilityByUniqueDate(datetimeStrings, endTimeJST, weeks)
+	cdfEnd, err := prediction.GetProbabilityFromDatetimes(datetimeStrings, endTimeJST, weeks)
 	if err != nil {
 		return 0.0
 	}
-	cdfStart, err := prediction.GetProbabilityByUniqueDate(datetimeStrings, startTimeJST, weeks)
+	cdfStart, err := prediction.GetProbabilityFromDatetimes(datetimeStrings, startTimeJST, weeks)
 	if err != nil {
 		return 0.0
 	}


### PR DESCRIPTION
## Summary
- `calcHourProbability` が `GetProbabilityByUniqueDate` を使用していたため、同じ日に複数の "start" ログがある場合（例: 09:00と14:00に作業開始）、最初の時刻のみが使用され2回目以降が無視されていた
- 日付重複排除をしない新関数 `GetProbabilityFromDatetimes` を `prediction` パッケージに追加し、`calcHourProbability` のみそちらを使うように変更
- 既存の `GetProbabilityByUniqueDate` と、それを使う `GetActivityProbability`（`/api/events/:id/probability` + 通知ロジック）は変更なし

## Test plan
- [x] `cd src && go build ./...` でビルド確認
- [ ] `/api/activities/probabilities` で同じ日に複数回活動があるケースで確率が分散することを確認
- [ ] `/api/events/:id/probability` が従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)