### PR TITLE
feat: イベント一覧取得API を追加

### DIFF
--- a/src/controller/api.go
+++ b/src/controller/api.go
@@ -42,6 +42,25 @@ type RegisterLogsRequest struct {
 	Logs []LogEntry `json:"logs" binding:"required,min=1"`
 }
 
+// GetEvents はEvent一覧を取得するAPIハンドラー
+// @Summary Event一覧を取得
+// @Tags events
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Failure 500 {object} map[string]interface{}
+// @Router /api/events [get]
+func GetEvents(c *gin.Context) {
+	events, err := service.GetEvents()
+	if err != nil {
+		respondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"data": events,
+	})
+}
+
 // GetTypes はType一覧を取得するAPIハンドラー
 // @Summary Type一覧を取得
 // @Tags types

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -57,6 +57,33 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/events": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "events"
+                ],
+                "summary": "Event一覧を取得",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/events/{id}/probability": {
             "get": {
                 "produces": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -51,6 +51,33 @@
                 }
             }
         },
+        "/api/events": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "events"
+                ],
+                "summary": "Event一覧を取得",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/events/{id}/probability": {
             "get": {
                 "produces": [

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -89,6 +89,24 @@ paths:
       summary: 全活動の時間帯別発生確率を取得
       tags:
       - activities
+  /api/events:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Event一覧を取得
+      tags:
+      - events
   /api/events/{id}/probability:
     get:
       parameters:

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -65,6 +65,7 @@ func Router() {
 	r.GET("/api/tools", controller.GetTools)
 	r.POST("/api/statuses", controller.PostRegisterStatuses)
 	r.GET("/api/statuses", controller.GetStatuses)
+	r.GET("/api/events", controller.GetEvents)
 	r.GET("/api/events/:id/probability", controller.GetEventProbability)
 	r.GET("/api/activities/probabilities", controller.GetAllActivityProbabilities)
 	r.POST("/api/logs", controller.PostRegisterLogs)


### PR DESCRIPTION
## Summary
- `GET /api/events` エンドポイントを追加し、Type・Tools をプリロードした全イベント一覧を取得可能に
- コントローラー、ルーター、Swaggerドキュメントを更新

## Test plan
- [ ] `GET /api/events` でイベント一覧がJSON形式で返却されることを確認
- [ ] Swagger UI (`/docs/`) に新エンドポイントが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)