### PR TITLE
feat: ローカルネットワークからのCORSアクセスを許可

### DIFF
--- a/src/router/router.go
+++ b/src/router/router.go
@@ -3,6 +3,8 @@ package router
 
 import (
 	"io"
+	"net"
+	"net/url"
 	"os"
 	"time"
 
@@ -27,6 +29,22 @@ func Router() {
 		AllowOrigins: []string{
 			"https://staywatch.kajilab.net",
 			"http://localhost:3000",
+		},
+		// ローカルネットワークからのアクセスを許可
+		AllowOriginFunc: func(origin string) bool {
+			u, err := url.Parse(origin)
+			if err != nil {
+				return false
+			}
+			host, _, err := net.SplitHostPort(u.Host)
+			if err != nil {
+				host = u.Host
+			}
+			ip := net.ParseIP(host)
+			if ip == nil {
+				return false
+			}
+			return ip.IsPrivate() || ip.IsLoopback()
 		},
 		// アクセスを許可したいHTTPメソッド
 		AllowMethods: []string{


### PR DESCRIPTION
## Summary
- `AllowOriginFunc` を追加し、プライベートIP（`192.168.*`, `10.*`, `172.16-31.*`）およびループバックアドレスからのCORSアクセスを許可
- 既存の `AllowOrigins`（本番・localhost:3000）はそのまま維持

## Test plan
- [ ] ローカルネットワーク内の端末からAPIにアクセスし、CORSエラーが発生しないことを確認
- [ ] 本番環境（staywatch.kajilab.net）からのアクセスが引き続き動作することを確認
- [ ] 外部IPからのアクセスがブロックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)