### PR TITLE
feat: LogEntryのEventIDをstring型に変更

### DIFF
--- a/src/controller/api.go
+++ b/src/controller/api.go
@@ -32,7 +32,7 @@ type RegisterStatusesRequest struct {
 
 // LogEntry はログ登録リクエストの1エントリを表す
 type LogEntry struct {
-	EventID   uint   `json:"event_id" binding:"required"`
+	EventID   string `json:"event_id" binding:"required"`
 	StatusID  uint   `json:"status_id" binding:"required"`
 	EventTime string `json:"event_time" binding:"required"` // RFC3339形式 JST (例: "2006-01-02T15:04:05+09:00")
 }
@@ -323,8 +323,13 @@ func PostRegisterLogs(c *gin.Context) {
 	// リクエストをサービス層の入力形式に変換
 	inputs := make([]service.LogEntryInput, len(req.Logs))
 	for i, entry := range req.Logs {
+		eventID, err := strconv.ParseUint(entry.EventID, 10, 32)
+		if err != nil {
+			respondError(c, http.StatusBadRequest, "invalid event_id")
+			return
+		}
 		inputs[i] = service.LogEntryInput{
-			EventID:   entry.EventID,
+			EventID:   uint(eventID),
 			StatusID:  entry.StatusID,
 			EventTime: entry.EventTime,
 		}

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -418,7 +418,7 @@ const docTemplate = `{
             ],
             "properties": {
                 "event_id": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "event_time": {
                     "description": "RFC3339形式 JST (例: \"2006-01-02T15:04:05+09:00\")",

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -412,7 +412,7 @@
             ],
             "properties": {
                 "event_id": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "event_time": {
                     "description": "RFC3339形式 JST (例: \"2006-01-02T15:04:05+09:00\")",

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -3,7 +3,7 @@ definitions:
   controller.LogEntry:
     properties:
       event_id:
-        type: integer
+        type: string
       event_time:
         description: 'RFC3339形式 JST (例: "2006-01-02T15:04:05+09:00")'
         type: string


### PR DESCRIPTION
## Summary
- `src/controller/api.go` の `LogEntry.EventID` を `uint` → `string` に変更
- サービス層 (`LogEntryInput.EventID`) は `uint` のままのため、コントローラ側で `strconv.ParseUint` による変換を追加（パース失敗時は 400 を返却）
- Swagger 定義 (`docs.go` / `swagger.json` / `swagger.yaml`) を再生成

## Test plan
- [ ] `POST /api/logs` に `event_id` を文字列で送信して 201 が返ることを確認
- [ ] `event_id` に数値変換できない文字列を送信して 400 が返ることを確認
- [ ] Swagger UI 上で `event_id` が string 型として表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)